### PR TITLE
Removes bls_linux.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ Go module for [celo-bls-snark-rs](https://github.com/celo-org/celo-bls-snark-rs/
 * Delete the old libs
 * Create a PR
 * The CI will now build all the libs and store them as tar.gz. artifact. Use it to update all the libs and commit them.
-* After the PR is merged, tag the version using `./scripts/tag_version.sh`
+* After the PR is merged, tag the version.
 
 If needed, you can remove an old tag using `./scripts/remove_tag.sh VERSION`.

--- a/bls/bls_linux.go
+++ b/bls/bls_linux.go
@@ -1,9 +1,0 @@
-// +build !android,!musl
-
-package bls
-
-/*
-#cgo LDFLAGS: -L${SRCDIR}/../libs/i686-unknown-linux-gnu -L${SRCDIR}/../libs/x86_64-unknown-linux-gnu -lbls_snark_sys -ldl -lm
-*/
-import "C"
-


### PR DESCRIPTION
The linking directives for linux 32/64-bit are already taken care of in bls_linux_32.go and bls_linux_64.go.