### PR TITLE
Fix windows library linker path

### DIFF
--- a/bls/bls_windows.go
+++ b/bls/bls_windows.go
@@ -3,7 +3,7 @@
 package bls
 
 /*
-#cgo LDFLAGS: -L${SRCDIR}/../libs/i686-pc-windows-gnu -lbls_snark_sys -lm -lws2_32 -luserenv -lunwind
+#cgo LDFLAGS: -L${SRCDIR}/../libs/i686-pc-windows-msvc -lbls_snark_sys -lm -lws2_32 -luserenv -lunwind
 */
 import "C"
 


### PR DESCRIPTION
I'm working on cross-compiling `celo-blockchain` on different platforms and I'm getting an error when trying to compile for windows/386. It led me to find that the linker flags are pointing to a folder that doesn't exist `libs/i686-pc-windows-gnu`. 
I've noticed that there is a `libs/i686-pc-windows-msvc` but I'm not sure if these are equivalent, and thus if my patch actually works ok, or if we need to specifically build a lib for `libs/i686-pc-windows-gnu`.

Update: I tried building off of this branch and I'm not getting the  `cannot find -lbls_snark_sys` error anymore
