### PR TITLE
fix: links linux builds to pthread

### DIFF
--- a/bls/bls_linux386.go
+++ b/bls/bls_linux386.go
@@ -3,6 +3,6 @@
 package bls
 
 /*
-#cgo LDFLAGS: -L${SRCDIR}/../libs/i686-unknown-linux-gnu -lbls_snark_sys -ldl -lm
+#cgo LDFLAGS: -L${SRCDIR}/../libs/i686-unknown-linux-gnu -lbls_snark_sys -ldl -lm -lpthread
 */
 import "C"

--- a/bls/bls_linux64.go
+++ b/bls/bls_linux64.go
@@ -3,6 +3,6 @@
 package bls
 
 /*
-#cgo LDFLAGS: -L${SRCDIR}/../libs/x86_64-unknown-linux-gnu -lbls_snark_sys -ldl -lm
+#cgo LDFLAGS: -L${SRCDIR}/../libs/x86_64-unknown-linux-gnu -lbls_snark_sys -ldl -lm -lpthread
 */
 import "C"


### PR DESCRIPTION
This is needed because Rosetta doesn't link to pthread otherwise.