### PR TITLE
Add plumbing for epoch SNARK message entropy

### DIFF
--- a/bls/bls.go
+++ b/bls/bls.go
@@ -478,13 +478,13 @@ func AggregateSignatures(signatures []*Signature) (*Signature, error) {
 	return aggregatedSignature, nil
 }
 
-func encodeEpochToBytes(epochIndex uint16, blockHash, parentHash EpochEntropy, maximumNonSigners uint32, publicKeys []*PublicKey, shouldEncodeAggregatedPublicKey bool) ([]byte, error) {
-	if len(publicKeys) == 0 {
+func encodeEpochToBytes(epochIndex uint16, blockHash, parentHash EpochEntropy, maximumNonSigners uint32, addedPublicKeys []*PublicKey, shouldEncodeAggregatedPublicKey bool) ([]byte, error) {
+	if len(addedPublicKeys) == 0 {
 		return nil, EmptySliceError
 	}
 
 	publicKeysPtrs := []*C.struct_PublicKey{}
-	for _, pk := range publicKeys {
+	for _, pk := range addedPublicKeys {
 		if pk == nil {
 			return nil, NilPointerError
 		}
@@ -515,10 +515,10 @@ func encodeEpochToBytes(epochIndex uint16, blockHash, parentHash EpochEntropy, m
 	return goBytes, nil
 }
 
-func EncodeEpochToBytes(epochIndex uint16, blockHash, parentHash EpochEntropy, maximumNonSigners uint32, publicKeys []*PublicKey) ([]byte, error) {
-	return encodeEpochToBytes(epochIndex, blockHash, parentHash, maximumNonSigners, publicKeys, false)
+func EncodeEpochToBytes(epochIndex uint16, blockHash, parentHash EpochEntropy, maximumNonSigners uint32, addedPublicKeys []*PublicKey) ([]byte, error) {
+	return encodeEpochToBytes(epochIndex, blockHash, parentHash, maximumNonSigners, addedPublicKeys, false)
 }
 
-func EncodeEpochToBytesWithAggregatedKey(epochIndex uint16, blockHash, parentHash EpochEntropy, maximumNonSigners uint32, publicKeys []*PublicKey) ([]byte, error) {
-	return encodeEpochToBytes(epochIndex, blockHash, parentHash, maximumNonSigners, publicKeys, true)
+func EncodeEpochToBytesWithAggregatedKey(epochIndex uint16, blockHash, parentHash EpochEntropy, maximumNonSigners uint32, addedPublicKeys []*PublicKey) ([]byte, error) {
+	return encodeEpochToBytes(epochIndex, blockHash, parentHash, maximumNonSigners, addedPublicKeys, true)
 }

--- a/bls/bls.h
+++ b/bls/bls.h
@@ -108,6 +108,8 @@ bool destroy_public_key(PublicKey *public_key);
 bool destroy_signature(Signature *signature);
 
 bool encode_epoch_block_to_bytes(unsigned short in_epoch_index,
+                                 uint8_t *block_hash,
+                                 uint8_t *parent_hash,
                                  unsigned int in_maximum_non_signers,
                                  const PublicKey *const *in_added_public_keys,
                                  int in_added_public_keys_len,

--- a/bls/bls_test.go
+++ b/bls/bls_test.go
@@ -192,12 +192,16 @@ func TestEncoding(t *testing.T) {
 	defer privateKey2.Destroy()
 	publicKey2, _ := privateKey2.ToPublic()
 
-	bytes, err := EncodeEpochToBytes(10, 20, []*PublicKey{publicKey, publicKey2})
+	var blockHash, parentHash EpochEntropy
+	copy(blockHash[:], "foo")
+	copy(parentHash[:], "bar")
+
+	bytes, err := EncodeEpochToBytes(10, blockHash, parentHash, 20, []*PublicKey{publicKey, publicKey2})
 	if err != nil {
 		t.Fatalf("failed encoding epoch bytes")
 	}
 	t.Logf("encoding: %s\n", hex.EncodeToString(bytes))
-	bytesWithApk, err := EncodeEpochToBytesWithAggregatedKey(10, 20, []*PublicKey{publicKey, publicKey2})
+	bytesWithApk, err := EncodeEpochToBytesWithAggregatedKey(10, blockHash, parentHash, 20, []*PublicKey{publicKey, publicKey2})
 	if err != nil {
 		t.Fatalf("failed encoding epoch bytes")
 	}
@@ -252,11 +256,11 @@ func TestAggregateSignaturesErrors(t *testing.T) {
 func TestEncodeErrors(t *testing.T) {
 	InitBLSCrypto()
 
-	_, err := EncodeEpochToBytes(0, 0, []*PublicKey{})
+	_, err := EncodeEpochToBytes(0, EpochEntropy{}, EpochEntropy{}, 0, []*PublicKey{})
 	if err != EmptySliceError {
 		t.Fatalf("should have been an empty slice")
 	}
-	_, err = EncodeEpochToBytes(0, 0, nil)
+	_, err = EncodeEpochToBytes(0, EpochEntropy{}, EpochEntropy{}, 0, nil)
 	if err != EmptySliceError {
 		t.Fatalf("should have been an empty slice")
 	}

--- a/bls/bls_test.go
+++ b/bls/bls_test.go
@@ -211,6 +211,22 @@ func TestEncoding(t *testing.T) {
 	}
 }
 
+func TestEncodingWithoutEntropy(t *testing.T) {
+	InitBLSCrypto()
+	privateKey, _ := GeneratePrivateKey()
+	defer privateKey.Destroy()
+	publicKey, _ := privateKey.ToPublic()
+
+	privateKey2, _ := GeneratePrivateKey()
+	defer privateKey2.Destroy()
+	publicKey2, _ := privateKey2.ToPublic()
+
+	_, err := EncodeEpochToBytesWithoutEntropy(10, 20, []*PublicKey{publicKey, publicKey2})
+	if err != nil {
+		t.Fatalf("failed encoding epoch bytes")
+	}
+}
+
 func TestAggregatePublicKeysErrors(t *testing.T) {
 	InitBLSCrypto()
 	privateKey, _ := GeneratePrivateKey()


### PR DESCRIPTION
Adds support for encoding unpredictable values, using the block hash, into the epoch SNARK message. Related to https://github.com/celo-org/celo-blockchain/pull/1158