### PR TITLE
all: run go fmt on everything

### DIFF
--- a/bls/bls_android.go
+++ b/bls/bls_android.go
@@ -1,9 +1,10 @@
+//go:build android
 // +build android
 
 package bls
 
 import (
-    blsRoute "github.com/celo-org/celo-bls-go-android/bls"
+	blsRoute "github.com/celo-org/celo-bls-go-android/bls"
 )
 
 const (
@@ -28,84 +29,84 @@ type PrivateKey = blsRoute.PrivateKey
 type PublicKey = blsRoute.PublicKey
 type Signature = blsRoute.Signature
 type SignedBlockHeader = blsRoute.SignedBlockHeader
-type EpochEntropy  = blsRoute.EpochEntropy
+type EpochEntropy = blsRoute.EpochEntropy
 
 func InitBLSCrypto() {
-    blsRoute.InitBLSCrypto()
+	blsRoute.InitBLSCrypto()
 }
 
 func GeneratePrivateKey() (*PrivateKey, error) {
-    return blsRoute.GeneratePrivateKey()
+	return blsRoute.GeneratePrivateKey()
 }
 
 func DeserializePrivateKey(privateKeyBytes []byte) (*PrivateKey, error) {
-    return blsRoute.DeserializePrivateKey(privateKeyBytes)
+	return blsRoute.DeserializePrivateKey(privateKeyBytes)
 }
 
 func HashDirect(message []byte, usePoP bool) ([]byte, error) {
-    return blsRoute.HashDirect(message, usePoP)
+	return blsRoute.HashDirect(message, usePoP)
 }
 
 func HashDirectWithAttempt(message []byte, usePoP bool) ([]byte, uint, error) {
-    return blsRoute.HashDirectWithAttempt(message, usePoP)
+	return blsRoute.HashDirectWithAttempt(message, usePoP)
 }
 
 func HashComposite(message []byte, extraData []byte) ([]byte, error) {
-    return blsRoute.HashComposite(message, extraData)
+	return blsRoute.HashComposite(message, extraData)
 }
 
 func HashDirectFirstStep(message []byte, hashBytes int32) ([]byte, error) {
-    return blsRoute.HashDirectFirstStep(message, hashBytes)
+	return blsRoute.HashDirectFirstStep(message, hashBytes)
 }
 
 func HashCRH(message []byte, hashBytes int32) ([]byte, error) {
-    return blsRoute.HashCRH(message, hashBytes)
+	return blsRoute.HashCRH(message, hashBytes)
 }
 
 func HashCompositeCIP22(message []byte, extraData []byte) ([]byte, uint8, error) {
-    return blsRoute.HashCompositeCIP22(message, extraData)
+	return blsRoute.HashCompositeCIP22(message, extraData)
 }
 
 func CompressSignature(signature []byte) ([]byte, error) {
-    return blsRoute.CompressSignature(signature)
+	return blsRoute.CompressSignature(signature)
 }
 
 func CompressPublickey(pubkey []byte) ([]byte, error) {
-    return blsRoute.CompressPublickey(pubkey)
+	return blsRoute.CompressPublickey(pubkey)
 }
 
 func DeserializePublicKey(publicKeyBytes []byte) (*PublicKey, error) {
-    return blsRoute.DeserializePublicKey(publicKeyBytes)
+	return blsRoute.DeserializePublicKey(publicKeyBytes)
 }
 
 func DeserializePublicKeyCached(publicKeyBytes []byte) (*PublicKey, error) {
-    return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
+	return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
 }
 
 func BatchVerifyEpochs(signedHeaders []*SignedBlockHeader, shouldUseCompositeHasher, shouldUseCIP22 bool) error {
-    return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
+	return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-    return DeserializeSignature(signatureBytes)
+	return DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {
-    return blsRoute.AggregatePublicKeys(publicKeys)
+	return blsRoute.AggregatePublicKeys(publicKeys)
 }
 
 func AggregatePublicKeysSubtract(aggregatedPublicKey *PublicKey, publicKeys []*PublicKey) (*PublicKey, error) {
-    return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
+	return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
 }
 
 func AggregateSignatures(signatures []*Signature) (*Signature, error) {
-    return blsRoute.AggregateSignatures(signatures)
+	return blsRoute.AggregateSignatures(signatures)
 }
 
 func EncodeEpochToBytesCIP22(epochIndex uint16, round uint8, blockHash, parentHash EpochEntropy, maximumNonSigners, maximumValidators uint32, addedPublicKeys []*PublicKey) ([]byte, []byte, error) {
-    return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
+	return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
 }
 
 func EncodeEpochToBytes(epochIndex uint16, maximumNonSigners uint32, addedPublicKeys []*PublicKey) ([]byte, error) {
-    return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
+	return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
 }

--- a/bls/bls_ios.go
+++ b/bls/bls_ios.go
@@ -1,9 +1,10 @@
+//go:build ios
 // +build ios
 
 package bls
 
 import (
-    blsRoute "github.com/celo-org/celo-bls-go-ios/bls"
+	blsRoute "github.com/celo-org/celo-bls-go-ios/bls"
 )
 
 const (
@@ -28,84 +29,84 @@ type PrivateKey = blsRoute.PrivateKey
 type PublicKey = blsRoute.PublicKey
 type Signature = blsRoute.Signature
 type SignedBlockHeader = blsRoute.SignedBlockHeader
-type EpochEntropy  = blsRoute.EpochEntropy
+type EpochEntropy = blsRoute.EpochEntropy
 
 func InitBLSCrypto() {
-    blsRoute.InitBLSCrypto()
+	blsRoute.InitBLSCrypto()
 }
 
 func GeneratePrivateKey() (*PrivateKey, error) {
-    return blsRoute.GeneratePrivateKey()
+	return blsRoute.GeneratePrivateKey()
 }
 
 func DeserializePrivateKey(privateKeyBytes []byte) (*PrivateKey, error) {
-    return blsRoute.DeserializePrivateKey(privateKeyBytes)
+	return blsRoute.DeserializePrivateKey(privateKeyBytes)
 }
 
 func HashDirect(message []byte, usePoP bool) ([]byte, error) {
-    return blsRoute.HashDirect(message, usePoP)
+	return blsRoute.HashDirect(message, usePoP)
 }
 
 func HashDirectWithAttempt(message []byte, usePoP bool) ([]byte, uint, error) {
-    return blsRoute.HashDirectWithAttempt(message, usePoP)
+	return blsRoute.HashDirectWithAttempt(message, usePoP)
 }
 
 func HashComposite(message []byte, extraData []byte) ([]byte, error) {
-    return blsRoute.HashComposite(message, extraData)
+	return blsRoute.HashComposite(message, extraData)
 }
 
 func HashDirectFirstStep(message []byte, hashBytes int32) ([]byte, error) {
-    return blsRoute.HashDirectFirstStep(message, hashBytes)
+	return blsRoute.HashDirectFirstStep(message, hashBytes)
 }
 
 func HashCRH(message []byte, hashBytes int32) ([]byte, error) {
-    return blsRoute.HashCRH(message, hashBytes)
+	return blsRoute.HashCRH(message, hashBytes)
 }
 
 func HashCompositeCIP22(message []byte, extraData []byte) ([]byte, uint8, error) {
-    return blsRoute.HashCompositeCIP22(message, extraData)
+	return blsRoute.HashCompositeCIP22(message, extraData)
 }
 
 func CompressSignature(signature []byte) ([]byte, error) {
-    return blsRoute.CompressSignature(signature)
+	return blsRoute.CompressSignature(signature)
 }
 
 func CompressPublickey(pubkey []byte) ([]byte, error) {
-    return blsRoute.CompressPublickey(pubkey)
+	return blsRoute.CompressPublickey(pubkey)
 }
 
 func DeserializePublicKey(publicKeyBytes []byte) (*PublicKey, error) {
-    return blsRoute.DeserializePublicKey(publicKeyBytes)
+	return blsRoute.DeserializePublicKey(publicKeyBytes)
 }
 
 func DeserializePublicKeyCached(publicKeyBytes []byte) (*PublicKey, error) {
-    return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
+	return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
 }
 
 func BatchVerifyEpochs(signedHeaders []*SignedBlockHeader, shouldUseCompositeHasher, shouldUseCIP22 bool) error {
-    return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
+	return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-    return DeserializeSignature(signatureBytes)
+	return DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {
-    return blsRoute.AggregatePublicKeys(publicKeys)
+	return blsRoute.AggregatePublicKeys(publicKeys)
 }
 
 func AggregatePublicKeysSubtract(aggregatedPublicKey *PublicKey, publicKeys []*PublicKey) (*PublicKey, error) {
-    return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
+	return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
 }
 
 func AggregateSignatures(signatures []*Signature) (*Signature, error) {
-    return blsRoute.AggregateSignatures(signatures)
+	return blsRoute.AggregateSignatures(signatures)
 }
 
 func EncodeEpochToBytesCIP22(epochIndex uint16, round uint8, blockHash, parentHash EpochEntropy, maximumNonSigners, maximumValidators uint32, addedPublicKeys []*PublicKey) ([]byte, []byte, error) {
-    return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
+	return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
 }
 
 func EncodeEpochToBytes(epochIndex uint16, maximumNonSigners uint32, addedPublicKeys []*PublicKey) ([]byte, error) {
-    return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
+	return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
 }

--- a/bls/bls_linux.go
+++ b/bls/bls_linux.go
@@ -1,9 +1,10 @@
+//go:build (linux && arm64) || (!android && linux && amd64 && !musl) || (linux && arm && !arm7) || arm7 || (!android && linux && 386 && !musl) || (!android && musl) || (linux && mips) || (linux && mips64) || (linux && mips64le) || (linux && mipsle)
 // +build linux,arm64 !android,linux,amd64,!musl linux,arm,!arm7 arm7 !android,linux,386,!musl !android,musl linux,mips linux,mips64 linux,mips64le linux,mipsle
 
 package bls
 
 import (
-    blsRoute "github.com/celo-org/celo-bls-go-linux/bls"
+	blsRoute "github.com/celo-org/celo-bls-go-linux/bls"
 )
 
 const (
@@ -28,84 +29,84 @@ type PrivateKey = blsRoute.PrivateKey
 type PublicKey = blsRoute.PublicKey
 type Signature = blsRoute.Signature
 type SignedBlockHeader = blsRoute.SignedBlockHeader
-type EpochEntropy  = blsRoute.EpochEntropy
+type EpochEntropy = blsRoute.EpochEntropy
 
 func InitBLSCrypto() {
-    blsRoute.InitBLSCrypto()
+	blsRoute.InitBLSCrypto()
 }
 
 func GeneratePrivateKey() (*PrivateKey, error) {
-    return blsRoute.GeneratePrivateKey()
+	return blsRoute.GeneratePrivateKey()
 }
 
 func DeserializePrivateKey(privateKeyBytes []byte) (*PrivateKey, error) {
-    return blsRoute.DeserializePrivateKey(privateKeyBytes)
+	return blsRoute.DeserializePrivateKey(privateKeyBytes)
 }
 
 func HashDirect(message []byte, usePoP bool) ([]byte, error) {
-    return blsRoute.HashDirect(message, usePoP)
+	return blsRoute.HashDirect(message, usePoP)
 }
 
 func HashDirectWithAttempt(message []byte, usePoP bool) ([]byte, uint, error) {
-    return blsRoute.HashDirectWithAttempt(message, usePoP)
+	return blsRoute.HashDirectWithAttempt(message, usePoP)
 }
 
 func HashComposite(message []byte, extraData []byte) ([]byte, error) {
-    return blsRoute.HashComposite(message, extraData)
+	return blsRoute.HashComposite(message, extraData)
 }
 
 func HashDirectFirstStep(message []byte, hashBytes int32) ([]byte, error) {
-    return blsRoute.HashDirectFirstStep(message, hashBytes)
+	return blsRoute.HashDirectFirstStep(message, hashBytes)
 }
 
 func HashCRH(message []byte, hashBytes int32) ([]byte, error) {
-    return blsRoute.HashCRH(message, hashBytes)
+	return blsRoute.HashCRH(message, hashBytes)
 }
 
 func HashCompositeCIP22(message []byte, extraData []byte) ([]byte, uint8, error) {
-    return blsRoute.HashCompositeCIP22(message, extraData)
+	return blsRoute.HashCompositeCIP22(message, extraData)
 }
 
 func CompressSignature(signature []byte) ([]byte, error) {
-    return blsRoute.CompressSignature(signature)
+	return blsRoute.CompressSignature(signature)
 }
 
 func CompressPublickey(pubkey []byte) ([]byte, error) {
-    return blsRoute.CompressPublickey(pubkey)
+	return blsRoute.CompressPublickey(pubkey)
 }
 
 func DeserializePublicKey(publicKeyBytes []byte) (*PublicKey, error) {
-    return blsRoute.DeserializePublicKey(publicKeyBytes)
+	return blsRoute.DeserializePublicKey(publicKeyBytes)
 }
 
 func DeserializePublicKeyCached(publicKeyBytes []byte) (*PublicKey, error) {
-    return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
+	return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
 }
 
 func BatchVerifyEpochs(signedHeaders []*SignedBlockHeader, shouldUseCompositeHasher, shouldUseCIP22 bool) error {
-    return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
+	return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-    return DeserializeSignature(signatureBytes)
+	return DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {
-    return blsRoute.AggregatePublicKeys(publicKeys)
+	return blsRoute.AggregatePublicKeys(publicKeys)
 }
 
 func AggregatePublicKeysSubtract(aggregatedPublicKey *PublicKey, publicKeys []*PublicKey) (*PublicKey, error) {
-    return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
+	return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
 }
 
 func AggregateSignatures(signatures []*Signature) (*Signature, error) {
-    return blsRoute.AggregateSignatures(signatures)
+	return blsRoute.AggregateSignatures(signatures)
 }
 
 func EncodeEpochToBytesCIP22(epochIndex uint16, round uint8, blockHash, parentHash EpochEntropy, maximumNonSigners, maximumValidators uint32, addedPublicKeys []*PublicKey) ([]byte, []byte, error) {
-    return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
+	return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
 }
 
 func EncodeEpochToBytes(epochIndex uint16, maximumNonSigners uint32, addedPublicKeys []*PublicKey) ([]byte, error) {
-    return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
+	return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
 }

--- a/bls/bls_macos.go
+++ b/bls/bls_macos.go
@@ -1,9 +1,10 @@
+//go:build (darwin && amd64 && !ios) || (darwin && arm64 && !ios)
 // +build darwin,amd64,!ios darwin,arm64,!ios
 
 package bls
 
 import (
-    blsRoute "github.com/celo-org/celo-bls-go-macos/bls"
+	blsRoute "github.com/celo-org/celo-bls-go-macos/bls"
 )
 
 const (
@@ -28,84 +29,84 @@ type PrivateKey = blsRoute.PrivateKey
 type PublicKey = blsRoute.PublicKey
 type Signature = blsRoute.Signature
 type SignedBlockHeader = blsRoute.SignedBlockHeader
-type EpochEntropy  = blsRoute.EpochEntropy
+type EpochEntropy = blsRoute.EpochEntropy
 
 func InitBLSCrypto() {
-    blsRoute.InitBLSCrypto()
+	blsRoute.InitBLSCrypto()
 }
 
 func GeneratePrivateKey() (*PrivateKey, error) {
-    return blsRoute.GeneratePrivateKey()
+	return blsRoute.GeneratePrivateKey()
 }
 
 func DeserializePrivateKey(privateKeyBytes []byte) (*PrivateKey, error) {
-    return blsRoute.DeserializePrivateKey(privateKeyBytes)
+	return blsRoute.DeserializePrivateKey(privateKeyBytes)
 }
 
 func HashDirect(message []byte, usePoP bool) ([]byte, error) {
-    return blsRoute.HashDirect(message, usePoP)
+	return blsRoute.HashDirect(message, usePoP)
 }
 
 func HashDirectWithAttempt(message []byte, usePoP bool) ([]byte, uint, error) {
-    return blsRoute.HashDirectWithAttempt(message, usePoP)
+	return blsRoute.HashDirectWithAttempt(message, usePoP)
 }
 
 func HashComposite(message []byte, extraData []byte) ([]byte, error) {
-    return blsRoute.HashComposite(message, extraData)
+	return blsRoute.HashComposite(message, extraData)
 }
 
 func HashDirectFirstStep(message []byte, hashBytes int32) ([]byte, error) {
-    return blsRoute.HashDirectFirstStep(message, hashBytes)
+	return blsRoute.HashDirectFirstStep(message, hashBytes)
 }
 
 func HashCRH(message []byte, hashBytes int32) ([]byte, error) {
-    return blsRoute.HashCRH(message, hashBytes)
+	return blsRoute.HashCRH(message, hashBytes)
 }
 
 func HashCompositeCIP22(message []byte, extraData []byte) ([]byte, uint8, error) {
-    return blsRoute.HashCompositeCIP22(message, extraData)
+	return blsRoute.HashCompositeCIP22(message, extraData)
 }
 
 func CompressSignature(signature []byte) ([]byte, error) {
-    return blsRoute.CompressSignature(signature)
+	return blsRoute.CompressSignature(signature)
 }
 
 func CompressPublickey(pubkey []byte) ([]byte, error) {
-    return blsRoute.CompressPublickey(pubkey)
+	return blsRoute.CompressPublickey(pubkey)
 }
 
 func DeserializePublicKey(publicKeyBytes []byte) (*PublicKey, error) {
-    return blsRoute.DeserializePublicKey(publicKeyBytes)
+	return blsRoute.DeserializePublicKey(publicKeyBytes)
 }
 
 func DeserializePublicKeyCached(publicKeyBytes []byte) (*PublicKey, error) {
-    return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
+	return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
 }
 
 func BatchVerifyEpochs(signedHeaders []*SignedBlockHeader, shouldUseCompositeHasher, shouldUseCIP22 bool) error {
-    return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
+	return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-    return DeserializeSignature(signatureBytes)
+	return DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {
-    return blsRoute.AggregatePublicKeys(publicKeys)
+	return blsRoute.AggregatePublicKeys(publicKeys)
 }
 
 func AggregatePublicKeysSubtract(aggregatedPublicKey *PublicKey, publicKeys []*PublicKey) (*PublicKey, error) {
-    return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
+	return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
 }
 
 func AggregateSignatures(signatures []*Signature) (*Signature, error) {
-    return blsRoute.AggregateSignatures(signatures)
+	return blsRoute.AggregateSignatures(signatures)
 }
 
 func EncodeEpochToBytesCIP22(epochIndex uint16, round uint8, blockHash, parentHash EpochEntropy, maximumNonSigners, maximumValidators uint32, addedPublicKeys []*PublicKey) ([]byte, []byte, error) {
-    return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
+	return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
 }
 
 func EncodeEpochToBytes(epochIndex uint16, maximumNonSigners uint32, addedPublicKeys []*PublicKey) ([]byte, error) {
-    return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
+	return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
 }

--- a/bls/bls_other.go
+++ b/bls/bls_other.go
@@ -1,9 +1,10 @@
+//go:build s390x
 // +build s390x
 
 package bls
 
 import (
-    blsRoute "github.com/celo-org/celo-bls-go-other/bls"
+	blsRoute "github.com/celo-org/celo-bls-go-other/bls"
 )
 
 const (
@@ -28,84 +29,84 @@ type PrivateKey = blsRoute.PrivateKey
 type PublicKey = blsRoute.PublicKey
 type Signature = blsRoute.Signature
 type SignedBlockHeader = blsRoute.SignedBlockHeader
-type EpochEntropy  = blsRoute.EpochEntropy
+type EpochEntropy = blsRoute.EpochEntropy
 
 func InitBLSCrypto() {
-    blsRoute.InitBLSCrypto()
+	blsRoute.InitBLSCrypto()
 }
 
 func GeneratePrivateKey() (*PrivateKey, error) {
-    return blsRoute.GeneratePrivateKey()
+	return blsRoute.GeneratePrivateKey()
 }
 
 func DeserializePrivateKey(privateKeyBytes []byte) (*PrivateKey, error) {
-    return blsRoute.DeserializePrivateKey(privateKeyBytes)
+	return blsRoute.DeserializePrivateKey(privateKeyBytes)
 }
 
 func HashDirect(message []byte, usePoP bool) ([]byte, error) {
-    return blsRoute.HashDirect(message, usePoP)
+	return blsRoute.HashDirect(message, usePoP)
 }
 
 func HashDirectWithAttempt(message []byte, usePoP bool) ([]byte, uint, error) {
-    return blsRoute.HashDirectWithAttempt(message, usePoP)
+	return blsRoute.HashDirectWithAttempt(message, usePoP)
 }
 
 func HashComposite(message []byte, extraData []byte) ([]byte, error) {
-    return blsRoute.HashComposite(message, extraData)
+	return blsRoute.HashComposite(message, extraData)
 }
 
 func HashDirectFirstStep(message []byte, hashBytes int32) ([]byte, error) {
-    return blsRoute.HashDirectFirstStep(message, hashBytes)
+	return blsRoute.HashDirectFirstStep(message, hashBytes)
 }
 
 func HashCRH(message []byte, hashBytes int32) ([]byte, error) {
-    return blsRoute.HashCRH(message, hashBytes)
+	return blsRoute.HashCRH(message, hashBytes)
 }
 
 func HashCompositeCIP22(message []byte, extraData []byte) ([]byte, uint8, error) {
-    return blsRoute.HashCompositeCIP22(message, extraData)
+	return blsRoute.HashCompositeCIP22(message, extraData)
 }
 
 func CompressSignature(signature []byte) ([]byte, error) {
-    return blsRoute.CompressSignature(signature)
+	return blsRoute.CompressSignature(signature)
 }
 
 func CompressPublickey(pubkey []byte) ([]byte, error) {
-    return blsRoute.CompressPublickey(pubkey)
+	return blsRoute.CompressPublickey(pubkey)
 }
 
 func DeserializePublicKey(publicKeyBytes []byte) (*PublicKey, error) {
-    return blsRoute.DeserializePublicKey(publicKeyBytes)
+	return blsRoute.DeserializePublicKey(publicKeyBytes)
 }
 
 func DeserializePublicKeyCached(publicKeyBytes []byte) (*PublicKey, error) {
-    return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
+	return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
 }
 
 func BatchVerifyEpochs(signedHeaders []*SignedBlockHeader, shouldUseCompositeHasher, shouldUseCIP22 bool) error {
-    return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
+	return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-    return DeserializeSignature(signatureBytes)
+	return DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {
-    return blsRoute.AggregatePublicKeys(publicKeys)
+	return blsRoute.AggregatePublicKeys(publicKeys)
 }
 
 func AggregatePublicKeysSubtract(aggregatedPublicKey *PublicKey, publicKeys []*PublicKey) (*PublicKey, error) {
-    return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
+	return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
 }
 
 func AggregateSignatures(signatures []*Signature) (*Signature, error) {
-    return blsRoute.AggregateSignatures(signatures)
+	return blsRoute.AggregateSignatures(signatures)
 }
 
 func EncodeEpochToBytesCIP22(epochIndex uint16, round uint8, blockHash, parentHash EpochEntropy, maximumNonSigners, maximumValidators uint32, addedPublicKeys []*PublicKey) ([]byte, []byte, error) {
-    return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
+	return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
 }
 
 func EncodeEpochToBytes(epochIndex uint16, maximumNonSigners uint32, addedPublicKeys []*PublicKey) ([]byte, error) {
-    return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
+	return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
 }

--- a/bls/bls_test.go
+++ b/bls/bls_test.go
@@ -94,7 +94,7 @@ func TestAggregatedSig(t *testing.T) {
 	publicKey, _ := privateKey.ToPublic()
 	message := []byte("test")
 	extraData := []byte("extra")
-	for _, cip22 := range []bool{ false, true } {
+	for _, cip22 := range []bool{false, true} {
 		signature, _ := privateKey.SignMessage(message, extraData, true, cip22)
 		err := publicKey.VerifySignature(message, extraData, signature, true, cip22)
 		if err != nil {
@@ -252,7 +252,7 @@ func TestAggregateSignaturesErrors(t *testing.T) {
 	defer privateKey.Destroy()
 	message := []byte("test")
 	extraData := []byte("extra")
-	for _, cip22 := range []bool{ false, true } {
+	for _, cip22 := range []bool{false, true} {
 		signature, _ := privateKey.SignMessage(message, extraData, true, cip22)
 
 		_, err := AggregateSignatures([]*Signature{signature, nil})
@@ -277,7 +277,7 @@ func TestEncodeErrors(t *testing.T) {
 	if err != EmptySliceError {
 		t.Fatalf("should have been an empty slice")
 	}
-	_, _, err = EncodeEpochToBytesCIP22(0, 5, EpochEntropy{}, EpochEntropy{}, 0,2, nil)
+	_, _, err = EncodeEpochToBytesCIP22(0, 5, EpochEntropy{}, EpochEntropy{}, 0, 2, nil)
 	if err != EmptySliceError {
 		t.Fatalf("should have been an empty slice")
 	}
@@ -302,7 +302,7 @@ func TestVerifySignatureErrors(t *testing.T) {
 	publicKey, _ := privateKey.ToPublic()
 	message := []byte("test")
 	extraData := []byte("extra")
-	for _, cip22 := range []bool{ false, true } {
+	for _, cip22 := range []bool{false, true} {
 		err := publicKey.VerifySignature(message, extraData, nil, false, cip22)
 		if err != NilPointerError {
 			t.Fatalf("should have been a nil pointer")

--- a/bls/bls_windows.go
+++ b/bls/bls_windows.go
@@ -1,9 +1,10 @@
+//go:build (windows && 386) || (windows && amd64)
 // +build windows,386 windows,amd64
 
 package bls
 
 import (
-    blsRoute "github.com/celo-org/celo-bls-go-windows/bls"
+	blsRoute "github.com/celo-org/celo-bls-go-windows/bls"
 )
 
 const (
@@ -28,84 +29,84 @@ type PrivateKey = blsRoute.PrivateKey
 type PublicKey = blsRoute.PublicKey
 type Signature = blsRoute.Signature
 type SignedBlockHeader = blsRoute.SignedBlockHeader
-type EpochEntropy  = blsRoute.EpochEntropy
+type EpochEntropy = blsRoute.EpochEntropy
 
 func InitBLSCrypto() {
-    blsRoute.InitBLSCrypto()
+	blsRoute.InitBLSCrypto()
 }
 
 func GeneratePrivateKey() (*PrivateKey, error) {
-    return blsRoute.GeneratePrivateKey()
+	return blsRoute.GeneratePrivateKey()
 }
 
 func DeserializePrivateKey(privateKeyBytes []byte) (*PrivateKey, error) {
-    return blsRoute.DeserializePrivateKey(privateKeyBytes)
+	return blsRoute.DeserializePrivateKey(privateKeyBytes)
 }
 
 func HashDirect(message []byte, usePoP bool) ([]byte, error) {
-    return blsRoute.HashDirect(message, usePoP)
+	return blsRoute.HashDirect(message, usePoP)
 }
 
 func HashDirectWithAttempt(message []byte, usePoP bool) ([]byte, uint, error) {
-    return blsRoute.HashDirectWithAttempt(message, usePoP)
+	return blsRoute.HashDirectWithAttempt(message, usePoP)
 }
 
 func HashComposite(message []byte, extraData []byte) ([]byte, error) {
-    return blsRoute.HashComposite(message, extraData)
+	return blsRoute.HashComposite(message, extraData)
 }
 
 func HashDirectFirstStep(message []byte, hashBytes int32) ([]byte, error) {
-    return blsRoute.HashDirectFirstStep(message, hashBytes)
+	return blsRoute.HashDirectFirstStep(message, hashBytes)
 }
 
 func HashCRH(message []byte, hashBytes int32) ([]byte, error) {
-    return blsRoute.HashCRH(message, hashBytes)
+	return blsRoute.HashCRH(message, hashBytes)
 }
 
 func HashCompositeCIP22(message []byte, extraData []byte) ([]byte, uint8, error) {
-    return blsRoute.HashCompositeCIP22(message, extraData)
+	return blsRoute.HashCompositeCIP22(message, extraData)
 }
 
 func CompressSignature(signature []byte) ([]byte, error) {
-    return blsRoute.CompressSignature(signature)
+	return blsRoute.CompressSignature(signature)
 }
 
 func CompressPublickey(pubkey []byte) ([]byte, error) {
-    return blsRoute.CompressPublickey(pubkey)
+	return blsRoute.CompressPublickey(pubkey)
 }
 
 func DeserializePublicKey(publicKeyBytes []byte) (*PublicKey, error) {
-    return blsRoute.DeserializePublicKey(publicKeyBytes)
+	return blsRoute.DeserializePublicKey(publicKeyBytes)
 }
 
 func DeserializePublicKeyCached(publicKeyBytes []byte) (*PublicKey, error) {
-    return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
+	return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
 }
 
 func BatchVerifyEpochs(signedHeaders []*SignedBlockHeader, shouldUseCompositeHasher, shouldUseCIP22 bool) error {
-    return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
+	return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-    return DeserializeSignature(signatureBytes)
+	return DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {
-    return blsRoute.AggregatePublicKeys(publicKeys)
+	return blsRoute.AggregatePublicKeys(publicKeys)
 }
 
 func AggregatePublicKeysSubtract(aggregatedPublicKey *PublicKey, publicKeys []*PublicKey) (*PublicKey, error) {
-    return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
+	return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
 }
 
 func AggregateSignatures(signatures []*Signature) (*Signature, error) {
-    return blsRoute.AggregateSignatures(signatures)
+	return blsRoute.AggregateSignatures(signatures)
 }
 
 func EncodeEpochToBytesCIP22(epochIndex uint16, round uint8, blockHash, parentHash EpochEntropy, maximumNonSigners, maximumValidators uint32, addedPublicKeys []*PublicKey) ([]byte, []byte, error) {
-    return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
+	return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
 }
 
 func EncodeEpochToBytes(epochIndex uint16, maximumNonSigners uint32, addedPublicKeys []*PublicKey) ([]byte, error) {
-    return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
+	return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
 }

--- a/cmd/distribute/distribute.go
+++ b/cmd/distribute/distribute.go
@@ -15,10 +15,10 @@ const LIB_NAME = "libbls_snark_sys.a"
 const LIB_WINDOWS_NAME = "bls_snark_sys.lib"
 
 type Platform struct {
-	Name string
-	BuildDirective string
+	Name             string
+	BuildDirective   string
 	LinkageDirective string
-	LibDirectories []string
+	LibDirectories   []string
 }
 
 func main() {

--- a/examples/utils/utils.go
+++ b/examples/utils/utils.go
@@ -7,7 +7,7 @@ const FIELD_SIZE_IN_CONTRACT = 32
 
 func ReverseAnyAndPad(s []byte) []byte {
 	s = ReverseAny(s)
-	padding := make([]byte, FIELD_SIZE_IN_CONTRACT- (len(s) %FIELD_SIZE_IN_CONTRACT))
+	padding := make([]byte, FIELD_SIZE_IN_CONTRACT-(len(s)%FIELD_SIZE_IN_CONTRACT))
 	z := append(padding, s...)
 	return z
 }

--- a/snark/snark_android.go
+++ b/snark/snark_android.go
@@ -1,9 +1,10 @@
+//go:build android
 // +build android
 
 package snark
 
 import (
-    snarkRoute "github.com/celo-org/celo-bls-go-android/snark"
+	snarkRoute "github.com/celo-org/celo-bls-go-android/snark"
 )
 
 var VerificationError = snarkRoute.VerificationError
@@ -22,5 +23,5 @@ func VerifyEpochs(
 	firstEpoch EpochBlock,
 	lastEpoch EpochBlock,
 ) error {
-    return snarkRoute.VerifyEpochs(verifyingKey , proof, firstEpoch, lastEpoch)
+	return snarkRoute.VerifyEpochs(verifyingKey, proof, firstEpoch, lastEpoch)
 }

--- a/snark/snark_ios.go
+++ b/snark/snark_ios.go
@@ -1,9 +1,10 @@
+//go:build ios
 // +build ios
 
 package snark
 
 import (
-    snarkRoute "github.com/celo-org/celo-bls-go-ios/snark"
+	snarkRoute "github.com/celo-org/celo-bls-go-ios/snark"
 )
 
 var VerificationError = snarkRoute.VerificationError
@@ -22,5 +23,5 @@ func VerifyEpochs(
 	firstEpoch EpochBlock,
 	lastEpoch EpochBlock,
 ) error {
-    return snarkRoute.VerifyEpochs(verifyingKey , proof, firstEpoch, lastEpoch)
+	return snarkRoute.VerifyEpochs(verifyingKey, proof, firstEpoch, lastEpoch)
 }

--- a/snark/snark_linux.go
+++ b/snark/snark_linux.go
@@ -1,9 +1,10 @@
+//go:build (linux && arm64) || (!android && linux && amd64 && !musl) || (linux && arm && !arm7) || arm7 || (!android && linux && 386 && !musl) || (!android && musl) || (linux && mips) || (linux && mips64) || (linux && mips64le) || (linux && mipsle)
 // +build linux,arm64 !android,linux,amd64,!musl linux,arm,!arm7 arm7 !android,linux,386,!musl !android,musl linux,mips linux,mips64 linux,mips64le linux,mipsle
 
 package snark
 
 import (
-    snarkRoute "github.com/celo-org/celo-bls-go-linux/snark"
+	snarkRoute "github.com/celo-org/celo-bls-go-linux/snark"
 )
 
 var VerificationError = snarkRoute.VerificationError
@@ -22,5 +23,5 @@ func VerifyEpochs(
 	firstEpoch EpochBlock,
 	lastEpoch EpochBlock,
 ) error {
-    return snarkRoute.VerifyEpochs(verifyingKey , proof, firstEpoch, lastEpoch)
+	return snarkRoute.VerifyEpochs(verifyingKey, proof, firstEpoch, lastEpoch)
 }

--- a/snark/snark_macos.go
+++ b/snark/snark_macos.go
@@ -1,9 +1,10 @@
+//go:build (darwin && amd64 && !ios) || (darwin && arm64 && !ios)
 // +build darwin,amd64,!ios darwin,arm64,!ios
 
 package snark
 
 import (
-    snarkRoute "github.com/celo-org/celo-bls-go-macos/snark"
+	snarkRoute "github.com/celo-org/celo-bls-go-macos/snark"
 )
 
 var VerificationError = snarkRoute.VerificationError
@@ -22,5 +23,5 @@ func VerifyEpochs(
 	firstEpoch EpochBlock,
 	lastEpoch EpochBlock,
 ) error {
-    return snarkRoute.VerifyEpochs(verifyingKey , proof, firstEpoch, lastEpoch)
+	return snarkRoute.VerifyEpochs(verifyingKey, proof, firstEpoch, lastEpoch)
 }

--- a/snark/snark_other.go
+++ b/snark/snark_other.go
@@ -1,9 +1,10 @@
+//go:build s390x
 // +build s390x
 
 package snark
 
 import (
-    snarkRoute "github.com/celo-org/celo-bls-go-other/snark"
+	snarkRoute "github.com/celo-org/celo-bls-go-other/snark"
 )
 
 var VerificationError = snarkRoute.VerificationError
@@ -22,5 +23,5 @@ func VerifyEpochs(
 	firstEpoch EpochBlock,
 	lastEpoch EpochBlock,
 ) error {
-    return snarkRoute.VerifyEpochs(verifyingKey , proof, firstEpoch, lastEpoch)
+	return snarkRoute.VerifyEpochs(verifyingKey, proof, firstEpoch, lastEpoch)
 }

--- a/snark/snark_windows.go
+++ b/snark/snark_windows.go
@@ -1,9 +1,10 @@
+//go:build (windows && 386) || (windows && amd64)
 // +build windows,386 windows,amd64
 
 package snark
 
 import (
-    snarkRoute "github.com/celo-org/celo-bls-go-windows/snark"
+	snarkRoute "github.com/celo-org/celo-bls-go-windows/snark"
 )
 
 var VerificationError = snarkRoute.VerificationError
@@ -22,5 +23,5 @@ func VerifyEpochs(
 	firstEpoch EpochBlock,
 	lastEpoch EpochBlock,
 ) error {
-    return snarkRoute.VerifyEpochs(verifyingKey , proof, firstEpoch, lastEpoch)
+	return snarkRoute.VerifyEpochs(verifyingKey, proof, firstEpoch, lastEpoch)
 }


### PR DESCRIPTION
Ran `go fmt` on the restructured branch so fmt-on-save in vscode stops adding random noise to my commits.