### PR TITLE
Fix infinite loop in DeserializeSignature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           root: .
           paths: .
 
-  go-local-tests:
+  go-test-linux:
     <<: *go_defaults
     working_directory: ~/app
     steps:
@@ -40,7 +40,7 @@ jobs:
             go get ./bls
             go test ./bls ./snark
 
-  go-tests:
+  go-test-all-targets:
     <<: *go_defaults
     working_directory: ~/app
     steps:
@@ -51,14 +51,14 @@ jobs:
           command: |
             cd ~/app
             go mod download github.com/celo-org/celo-bls-go-linux
-            ./scripts/run_distribute_in_ci.sh
+            go run cmd/distribute/distribute.go . ./platforms/platforms.json
             echo -e "\nreplace github.com/celo-org/celo-bls-go-linux => ./platforms/repos/celo-bls-go-linux" >> go.mod
             go get ./bls
             go test ./bls ./snark
       - store_artifacts:
           path: ~/app/go.mod
 
-  build-ci-libs:
+  build-libs-linux:
     <<: *rust_defaults
     working_directory: ~/app
     resource_class: large
@@ -77,7 +77,7 @@ jobs:
           root: .
           paths: .
 
-  bundle-libs:
+  build-and-bundle-libs-all-targets:
     working_directory: ~/app
     macos:
       xcode: 11.4.0
@@ -105,21 +105,24 @@ workflows:
     jobs:
       - checkout-repo
 
-      # build-ci-libs and go-local-tests build for linux and runs tests.
-      - build-ci-libs:
+      # build-libs-linux and go-test-linux builds for linux and runs tests.
+      - build-libs-linux:
           requires:
             - checkout-repo
-      - go-local-tests:
+      - go-test-linux:
           requires:
-            - build-ci-libs
+            - build-libs-linux
 
-      # bundle-libs and go-tests builds on all architectures.
+      # build-and-bundle-libs-all-targets and go-test-all-targets builds on all architectures,
+      # uploads the tar.gz bundled artifacts, then runs tests.
+      # Job is long-running and not needed on most commits, and so needs to be approved by a
+      # contributor before this workflow will run.
       - approval-to-bundle:
           type: approval
-      - bundle-libs:
+      - build-and-bundle-libs-all-targets:
           requires:
             - approval-to-bundle
             - checkout-repo
-      - go-tests:
+      - go-test-all-targets:
           requires:
-            - bundle-libs
+            - build-and-bundle-libs-all-targets

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,12 +6,12 @@ defaults: &defaults
 rust_defaults: &rust_defaults
   <<: *defaults
   docker:
-    - image: cimg/rust:latest
+    - image: cimg/rust:1.61
 
 go_defaults: &go_defaults
   <<: *defaults
   docker:
-    - image: cimg/go:latest
+    - image: cimg/go:1.18
 
 jobs:
   checkout-repo:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,14 +104,21 @@ workflows:
   run-tests:
     jobs:
       - checkout-repo
+
+      # build-ci-libs and go-local-tests build for linux and runs tests.
       - build-ci-libs:
           requires:
             - checkout-repo
       - go-local-tests:
           requires:
             - build-ci-libs
+
+      # bundle-libs and go-tests builds on all architectures.
+      - approval-to-bundle:
+          type: approval
       - bundle-libs:
           requires:
+            - approval-to-bundle
             - checkout-repo
       - go-tests:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,12 +6,12 @@ defaults: &defaults
 rust_defaults: &rust_defaults
   <<: *defaults
   docker:
-    - image: circleci/rust:latest
+    - image: cimg/rust:latest
 
 go_defaults: &go_defaults
   <<: *defaults
   docker:
-    - image: circleci/golang:latest
+    - image: cimg/go:latest
 
 jobs:
   checkout-repo:

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,8 @@ target/
 examples/bls_example
 cmd/distribute/distribute
 .idea
-libs
 platforms/repos
+
+# Ignore the built libraries
+libs
+libs.tar.gz

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Go module for [celo-bls-snark-rs](https://github.com/celo-org/celo-bls-snark-rs/
 * Create a new branch
 * Delete the old libs
 * Create a PR
+    * Include the keyword `BUNDLE` in your commit when you would like it to build on all
+        architectures. If you do not, it will only build linux.
 * The CI will now build all the libs and store them as tar.gz. artifact.
 * Download the tar file and extract it in the root of the repository. This will create the libs directory.
 * Run `go run cmd/distribute/distribute.go . platforms/platforms.json`. This will create all the repositories for the different packages.

--- a/README.md
+++ b/README.md
@@ -5,14 +5,21 @@ Go module for [celo-bls-snark-rs](https://github.com/celo-org/celo-bls-snark-rs/
 
 ## Release process
 
-* Create a new branch
-* Delete the old libs
-* Create a PR
-    * Include the keyword `BUNDLE` in your commit when you would like it to build on all
-        architectures. If you do not, it will only build linux.
-* The CI will now build all the libs and store them as tar.gz. artifact.
+[CircleCI] is configured to build release libraries for all supported architectures and operating
+systems. Building and bundling of new releases can be achieved through the following process.
+
+* Create a new branch.
+* Delete the old `./libs` folder, if it exists.
+* Create a PR.
+* On each commit, CI will run:
+    * By default, it will build and test the code on amd64 Linux.
+    * Upon [approval], by a contributor with push access, CI will the libs for all targets and store them as tar.gz artifact.
+
 * Download the tar file and extract it in the root of the repository. This will create the libs directory.
 * Run `go run cmd/distribute/distribute.go . platforms/platforms.json`. This will create all the repositories for the different packages.
 * Run `./scripts/push_and_tag.sh TAG` with a chosen `TAG`. This will create a tag in each of the repos and update the go.mod.
 * Merge the PR, so master will be up to date.
 * Run `./scripts/push_and_tag_master.sh`, to push the tag to the main repository.
+
+[CircleCI]: https://app.circleci.com/pipelines/github/celo-org/celo-bls-go
+[approval]: https://circleci.com/docs/2.0/workflows/#holding-a-workflow-for-a-manual-approval

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ systems. Building and bundling of new releases can be achieved through the follo
 * Download the `libs.tar.gz` file and extract it in the root of the repository. This will create the `./libs` directory.
 * Run `go run cmd/distribute/distribute.go . platforms/platforms.json`. This will create all the repositories for the different packages.
 * Run `./scripts/push_and_tag.sh TAG` with a chosen `TAG`. This will create a tag in each of the repos and update the go.mod.
+    * Tag should be formated as a semver such as `v0.1.2`.
 * Merge the PR, so master will be up to date.
 * Run `./scripts/push_and_tag_master.sh`, to push the tag to the main repository.
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ systems. Building and bundling of new releases can be achieved through the follo
 * Create a PR.
 * On each commit, CI will run:
     * By default, it will build and test the code on amd64 Linux.
-    * Upon [approval], by a contributor with push access, CI will the libs for all targets and store them as tar.gz artifact.
+    * Upon [approval] by a contributor with push access, CI will build the libs for all targets and store them as a `libs.tar.gz` artifact on the `build-and-bundle-libs-all-targets` job.
 
-* Download the tar file and extract it in the root of the repository. This will create the libs directory.
+* Download the `libs.tar.gz` file and extract it in the root of the repository. This will create the `./libs` directory.
 * Run `go run cmd/distribute/distribute.go . platforms/platforms.json`. This will create all the repositories for the different packages.
 * Run `./scripts/push_and_tag.sh TAG` with a chosen `TAG`. This will create a tag in each of the repos and update the go.mod.
 * Merge the PR, so master will be up to date.

--- a/bls/bls_android.go
+++ b/bls/bls_android.go
@@ -1,10 +1,9 @@
-//go:build android
 // +build android
 
 package bls
 
 import (
-	blsRoute "github.com/celo-org/celo-bls-go-android/bls"
+    blsRoute "github.com/celo-org/celo-bls-go-android/bls"
 )
 
 const (
@@ -32,81 +31,81 @@ type SignedBlockHeader = blsRoute.SignedBlockHeader
 type EpochEntropy = blsRoute.EpochEntropy
 
 func InitBLSCrypto() {
-	blsRoute.InitBLSCrypto()
+    blsRoute.InitBLSCrypto()
 }
 
 func GeneratePrivateKey() (*PrivateKey, error) {
-	return blsRoute.GeneratePrivateKey()
+    return blsRoute.GeneratePrivateKey()
 }
 
 func DeserializePrivateKey(privateKeyBytes []byte) (*PrivateKey, error) {
-	return blsRoute.DeserializePrivateKey(privateKeyBytes)
+    return blsRoute.DeserializePrivateKey(privateKeyBytes)
 }
 
 func HashDirect(message []byte, usePoP bool) ([]byte, error) {
-	return blsRoute.HashDirect(message, usePoP)
+    return blsRoute.HashDirect(message, usePoP)
 }
 
 func HashDirectWithAttempt(message []byte, usePoP bool) ([]byte, uint, error) {
-	return blsRoute.HashDirectWithAttempt(message, usePoP)
+    return blsRoute.HashDirectWithAttempt(message, usePoP)
 }
 
 func HashComposite(message []byte, extraData []byte) ([]byte, error) {
-	return blsRoute.HashComposite(message, extraData)
+    return blsRoute.HashComposite(message, extraData)
 }
 
 func HashDirectFirstStep(message []byte, hashBytes int32) ([]byte, error) {
-	return blsRoute.HashDirectFirstStep(message, hashBytes)
+    return blsRoute.HashDirectFirstStep(message, hashBytes)
 }
 
 func HashCRH(message []byte, hashBytes int32) ([]byte, error) {
-	return blsRoute.HashCRH(message, hashBytes)
+    return blsRoute.HashCRH(message, hashBytes)
 }
 
 func HashCompositeCIP22(message []byte, extraData []byte) ([]byte, uint8, error) {
-	return blsRoute.HashCompositeCIP22(message, extraData)
+    return blsRoute.HashCompositeCIP22(message, extraData)
 }
 
 func CompressSignature(signature []byte) ([]byte, error) {
-	return blsRoute.CompressSignature(signature)
+    return blsRoute.CompressSignature(signature)
 }
 
 func CompressPublickey(pubkey []byte) ([]byte, error) {
-	return blsRoute.CompressPublickey(pubkey)
+    return blsRoute.CompressPublickey(pubkey)
 }
 
 func DeserializePublicKey(publicKeyBytes []byte) (*PublicKey, error) {
-	return blsRoute.DeserializePublicKey(publicKeyBytes)
+    return blsRoute.DeserializePublicKey(publicKeyBytes)
 }
 
 func DeserializePublicKeyCached(publicKeyBytes []byte) (*PublicKey, error) {
-	return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
+    return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
 }
 
 func BatchVerifyEpochs(signedHeaders []*SignedBlockHeader, shouldUseCompositeHasher, shouldUseCIP22 bool) error {
-	return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
+    return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-	return blsRoute.DeserializeSignature(signatureBytes)
+    return blsRoute.DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {
-	return blsRoute.AggregatePublicKeys(publicKeys)
+    return blsRoute.AggregatePublicKeys(publicKeys)
 }
 
 func AggregatePublicKeysSubtract(aggregatedPublicKey *PublicKey, publicKeys []*PublicKey) (*PublicKey, error) {
-	return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
+    return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
 }
 
 func AggregateSignatures(signatures []*Signature) (*Signature, error) {
-	return blsRoute.AggregateSignatures(signatures)
+    return blsRoute.AggregateSignatures(signatures)
 }
 
 func EncodeEpochToBytesCIP22(epochIndex uint16, round uint8, blockHash, parentHash EpochEntropy, maximumNonSigners, maximumValidators uint32, addedPublicKeys []*PublicKey) ([]byte, []byte, error) {
-	return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
+    return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
 }
 
 func EncodeEpochToBytes(epochIndex uint16, maximumNonSigners uint32, addedPublicKeys []*PublicKey) ([]byte, error) {
-	return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
+    return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
 }

--- a/bls/bls_android.go
+++ b/bls/bls_android.go
@@ -1,9 +1,10 @@
+//go:build android
 // +build android
 
 package bls
 
 import (
-    blsRoute "github.com/celo-org/celo-bls-go-android/bls"
+	blsRoute "github.com/celo-org/celo-bls-go-android/bls"
 )
 
 const (
@@ -28,84 +29,84 @@ type PrivateKey = blsRoute.PrivateKey
 type PublicKey = blsRoute.PublicKey
 type Signature = blsRoute.Signature
 type SignedBlockHeader = blsRoute.SignedBlockHeader
-type EpochEntropy  = blsRoute.EpochEntropy
+type EpochEntropy = blsRoute.EpochEntropy
 
 func InitBLSCrypto() {
-    blsRoute.InitBLSCrypto()
+	blsRoute.InitBLSCrypto()
 }
 
 func GeneratePrivateKey() (*PrivateKey, error) {
-    return blsRoute.GeneratePrivateKey()
+	return blsRoute.GeneratePrivateKey()
 }
 
 func DeserializePrivateKey(privateKeyBytes []byte) (*PrivateKey, error) {
-    return blsRoute.DeserializePrivateKey(privateKeyBytes)
+	return blsRoute.DeserializePrivateKey(privateKeyBytes)
 }
 
 func HashDirect(message []byte, usePoP bool) ([]byte, error) {
-    return blsRoute.HashDirect(message, usePoP)
+	return blsRoute.HashDirect(message, usePoP)
 }
 
 func HashDirectWithAttempt(message []byte, usePoP bool) ([]byte, uint, error) {
-    return blsRoute.HashDirectWithAttempt(message, usePoP)
+	return blsRoute.HashDirectWithAttempt(message, usePoP)
 }
 
 func HashComposite(message []byte, extraData []byte) ([]byte, error) {
-    return blsRoute.HashComposite(message, extraData)
+	return blsRoute.HashComposite(message, extraData)
 }
 
 func HashDirectFirstStep(message []byte, hashBytes int32) ([]byte, error) {
-    return blsRoute.HashDirectFirstStep(message, hashBytes)
+	return blsRoute.HashDirectFirstStep(message, hashBytes)
 }
 
 func HashCRH(message []byte, hashBytes int32) ([]byte, error) {
-    return blsRoute.HashCRH(message, hashBytes)
+	return blsRoute.HashCRH(message, hashBytes)
 }
 
 func HashCompositeCIP22(message []byte, extraData []byte) ([]byte, uint8, error) {
-    return blsRoute.HashCompositeCIP22(message, extraData)
+	return blsRoute.HashCompositeCIP22(message, extraData)
 }
 
 func CompressSignature(signature []byte) ([]byte, error) {
-    return blsRoute.CompressSignature(signature)
+	return blsRoute.CompressSignature(signature)
 }
 
 func CompressPublickey(pubkey []byte) ([]byte, error) {
-    return blsRoute.CompressPublickey(pubkey)
+	return blsRoute.CompressPublickey(pubkey)
 }
 
 func DeserializePublicKey(publicKeyBytes []byte) (*PublicKey, error) {
-    return blsRoute.DeserializePublicKey(publicKeyBytes)
+	return blsRoute.DeserializePublicKey(publicKeyBytes)
 }
 
 func DeserializePublicKeyCached(publicKeyBytes []byte) (*PublicKey, error) {
-    return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
+	return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
 }
 
 func BatchVerifyEpochs(signedHeaders []*SignedBlockHeader, shouldUseCompositeHasher, shouldUseCIP22 bool) error {
-    return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
+	return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-    return DeserializeSignature(signatureBytes)
+	return blsRoute.DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {
-    return blsRoute.AggregatePublicKeys(publicKeys)
+	return blsRoute.AggregatePublicKeys(publicKeys)
 }
 
 func AggregatePublicKeysSubtract(aggregatedPublicKey *PublicKey, publicKeys []*PublicKey) (*PublicKey, error) {
-    return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
+	return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
 }
 
 func AggregateSignatures(signatures []*Signature) (*Signature, error) {
-    return blsRoute.AggregateSignatures(signatures)
+	return blsRoute.AggregateSignatures(signatures)
 }
 
 func EncodeEpochToBytesCIP22(epochIndex uint16, round uint8, blockHash, parentHash EpochEntropy, maximumNonSigners, maximumValidators uint32, addedPublicKeys []*PublicKey) ([]byte, []byte, error) {
-    return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
+	return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
 }
 
 func EncodeEpochToBytes(epochIndex uint16, maximumNonSigners uint32, addedPublicKeys []*PublicKey) ([]byte, error) {
-    return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
+	return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
 }

--- a/bls/bls_ios.go
+++ b/bls/bls_ios.go
@@ -1,10 +1,9 @@
-//go:build ios
 // +build ios
 
 package bls
 
 import (
-	blsRoute "github.com/celo-org/celo-bls-go-ios/bls"
+    blsRoute "github.com/celo-org/celo-bls-go-ios/bls"
 )
 
 const (
@@ -32,81 +31,81 @@ type SignedBlockHeader = blsRoute.SignedBlockHeader
 type EpochEntropy = blsRoute.EpochEntropy
 
 func InitBLSCrypto() {
-	blsRoute.InitBLSCrypto()
+    blsRoute.InitBLSCrypto()
 }
 
 func GeneratePrivateKey() (*PrivateKey, error) {
-	return blsRoute.GeneratePrivateKey()
+    return blsRoute.GeneratePrivateKey()
 }
 
 func DeserializePrivateKey(privateKeyBytes []byte) (*PrivateKey, error) {
-	return blsRoute.DeserializePrivateKey(privateKeyBytes)
+    return blsRoute.DeserializePrivateKey(privateKeyBytes)
 }
 
 func HashDirect(message []byte, usePoP bool) ([]byte, error) {
-	return blsRoute.HashDirect(message, usePoP)
+    return blsRoute.HashDirect(message, usePoP)
 }
 
 func HashDirectWithAttempt(message []byte, usePoP bool) ([]byte, uint, error) {
-	return blsRoute.HashDirectWithAttempt(message, usePoP)
+    return blsRoute.HashDirectWithAttempt(message, usePoP)
 }
 
 func HashComposite(message []byte, extraData []byte) ([]byte, error) {
-	return blsRoute.HashComposite(message, extraData)
+    return blsRoute.HashComposite(message, extraData)
 }
 
 func HashDirectFirstStep(message []byte, hashBytes int32) ([]byte, error) {
-	return blsRoute.HashDirectFirstStep(message, hashBytes)
+    return blsRoute.HashDirectFirstStep(message, hashBytes)
 }
 
 func HashCRH(message []byte, hashBytes int32) ([]byte, error) {
-	return blsRoute.HashCRH(message, hashBytes)
+    return blsRoute.HashCRH(message, hashBytes)
 }
 
 func HashCompositeCIP22(message []byte, extraData []byte) ([]byte, uint8, error) {
-	return blsRoute.HashCompositeCIP22(message, extraData)
+    return blsRoute.HashCompositeCIP22(message, extraData)
 }
 
 func CompressSignature(signature []byte) ([]byte, error) {
-	return blsRoute.CompressSignature(signature)
+    return blsRoute.CompressSignature(signature)
 }
 
 func CompressPublickey(pubkey []byte) ([]byte, error) {
-	return blsRoute.CompressPublickey(pubkey)
+    return blsRoute.CompressPublickey(pubkey)
 }
 
 func DeserializePublicKey(publicKeyBytes []byte) (*PublicKey, error) {
-	return blsRoute.DeserializePublicKey(publicKeyBytes)
+    return blsRoute.DeserializePublicKey(publicKeyBytes)
 }
 
 func DeserializePublicKeyCached(publicKeyBytes []byte) (*PublicKey, error) {
-	return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
+    return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
 }
 
 func BatchVerifyEpochs(signedHeaders []*SignedBlockHeader, shouldUseCompositeHasher, shouldUseCIP22 bool) error {
-	return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
+    return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-	return blsRoute.DeserializeSignature(signatureBytes)
+    return blsRoute.DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {
-	return blsRoute.AggregatePublicKeys(publicKeys)
+    return blsRoute.AggregatePublicKeys(publicKeys)
 }
 
 func AggregatePublicKeysSubtract(aggregatedPublicKey *PublicKey, publicKeys []*PublicKey) (*PublicKey, error) {
-	return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
+    return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
 }
 
 func AggregateSignatures(signatures []*Signature) (*Signature, error) {
-	return blsRoute.AggregateSignatures(signatures)
+    return blsRoute.AggregateSignatures(signatures)
 }
 
 func EncodeEpochToBytesCIP22(epochIndex uint16, round uint8, blockHash, parentHash EpochEntropy, maximumNonSigners, maximumValidators uint32, addedPublicKeys []*PublicKey) ([]byte, []byte, error) {
-	return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
+    return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
 }
 
 func EncodeEpochToBytes(epochIndex uint16, maximumNonSigners uint32, addedPublicKeys []*PublicKey) ([]byte, error) {
-	return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
+    return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
 }

--- a/bls/bls_ios.go
+++ b/bls/bls_ios.go
@@ -1,9 +1,10 @@
+//go:build ios
 // +build ios
 
 package bls
 
 import (
-    blsRoute "github.com/celo-org/celo-bls-go-ios/bls"
+	blsRoute "github.com/celo-org/celo-bls-go-ios/bls"
 )
 
 const (
@@ -28,84 +29,84 @@ type PrivateKey = blsRoute.PrivateKey
 type PublicKey = blsRoute.PublicKey
 type Signature = blsRoute.Signature
 type SignedBlockHeader = blsRoute.SignedBlockHeader
-type EpochEntropy  = blsRoute.EpochEntropy
+type EpochEntropy = blsRoute.EpochEntropy
 
 func InitBLSCrypto() {
-    blsRoute.InitBLSCrypto()
+	blsRoute.InitBLSCrypto()
 }
 
 func GeneratePrivateKey() (*PrivateKey, error) {
-    return blsRoute.GeneratePrivateKey()
+	return blsRoute.GeneratePrivateKey()
 }
 
 func DeserializePrivateKey(privateKeyBytes []byte) (*PrivateKey, error) {
-    return blsRoute.DeserializePrivateKey(privateKeyBytes)
+	return blsRoute.DeserializePrivateKey(privateKeyBytes)
 }
 
 func HashDirect(message []byte, usePoP bool) ([]byte, error) {
-    return blsRoute.HashDirect(message, usePoP)
+	return blsRoute.HashDirect(message, usePoP)
 }
 
 func HashDirectWithAttempt(message []byte, usePoP bool) ([]byte, uint, error) {
-    return blsRoute.HashDirectWithAttempt(message, usePoP)
+	return blsRoute.HashDirectWithAttempt(message, usePoP)
 }
 
 func HashComposite(message []byte, extraData []byte) ([]byte, error) {
-    return blsRoute.HashComposite(message, extraData)
+	return blsRoute.HashComposite(message, extraData)
 }
 
 func HashDirectFirstStep(message []byte, hashBytes int32) ([]byte, error) {
-    return blsRoute.HashDirectFirstStep(message, hashBytes)
+	return blsRoute.HashDirectFirstStep(message, hashBytes)
 }
 
 func HashCRH(message []byte, hashBytes int32) ([]byte, error) {
-    return blsRoute.HashCRH(message, hashBytes)
+	return blsRoute.HashCRH(message, hashBytes)
 }
 
 func HashCompositeCIP22(message []byte, extraData []byte) ([]byte, uint8, error) {
-    return blsRoute.HashCompositeCIP22(message, extraData)
+	return blsRoute.HashCompositeCIP22(message, extraData)
 }
 
 func CompressSignature(signature []byte) ([]byte, error) {
-    return blsRoute.CompressSignature(signature)
+	return blsRoute.CompressSignature(signature)
 }
 
 func CompressPublickey(pubkey []byte) ([]byte, error) {
-    return blsRoute.CompressPublickey(pubkey)
+	return blsRoute.CompressPublickey(pubkey)
 }
 
 func DeserializePublicKey(publicKeyBytes []byte) (*PublicKey, error) {
-    return blsRoute.DeserializePublicKey(publicKeyBytes)
+	return blsRoute.DeserializePublicKey(publicKeyBytes)
 }
 
 func DeserializePublicKeyCached(publicKeyBytes []byte) (*PublicKey, error) {
-    return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
+	return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
 }
 
 func BatchVerifyEpochs(signedHeaders []*SignedBlockHeader, shouldUseCompositeHasher, shouldUseCIP22 bool) error {
-    return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
+	return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-    return DeserializeSignature(signatureBytes)
+	return blsRoute.DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {
-    return blsRoute.AggregatePublicKeys(publicKeys)
+	return blsRoute.AggregatePublicKeys(publicKeys)
 }
 
 func AggregatePublicKeysSubtract(aggregatedPublicKey *PublicKey, publicKeys []*PublicKey) (*PublicKey, error) {
-    return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
+	return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
 }
 
 func AggregateSignatures(signatures []*Signature) (*Signature, error) {
-    return blsRoute.AggregateSignatures(signatures)
+	return blsRoute.AggregateSignatures(signatures)
 }
 
 func EncodeEpochToBytesCIP22(epochIndex uint16, round uint8, blockHash, parentHash EpochEntropy, maximumNonSigners, maximumValidators uint32, addedPublicKeys []*PublicKey) ([]byte, []byte, error) {
-    return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
+	return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
 }
 
 func EncodeEpochToBytes(epochIndex uint16, maximumNonSigners uint32, addedPublicKeys []*PublicKey) ([]byte, error) {
-    return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
+	return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
 }

--- a/bls/bls_linux.go
+++ b/bls/bls_linux.go
@@ -1,10 +1,9 @@
-//go:build (linux && arm64) || (!android && linux && amd64 && !musl) || (linux && arm && !arm7) || arm7 || (!android && linux && 386 && !musl) || (!android && musl) || (linux && mips) || (linux && mips64) || (linux && mips64le) || (linux && mipsle)
 // +build linux,arm64 !android,linux,amd64,!musl linux,arm,!arm7 arm7 !android,linux,386,!musl !android,musl linux,mips linux,mips64 linux,mips64le linux,mipsle
 
 package bls
 
 import (
-	blsRoute "github.com/celo-org/celo-bls-go-linux/bls"
+    blsRoute "github.com/celo-org/celo-bls-go-linux/bls"
 )
 
 const (
@@ -32,81 +31,81 @@ type SignedBlockHeader = blsRoute.SignedBlockHeader
 type EpochEntropy = blsRoute.EpochEntropy
 
 func InitBLSCrypto() {
-	blsRoute.InitBLSCrypto()
+    blsRoute.InitBLSCrypto()
 }
 
 func GeneratePrivateKey() (*PrivateKey, error) {
-	return blsRoute.GeneratePrivateKey()
+    return blsRoute.GeneratePrivateKey()
 }
 
 func DeserializePrivateKey(privateKeyBytes []byte) (*PrivateKey, error) {
-	return blsRoute.DeserializePrivateKey(privateKeyBytes)
+    return blsRoute.DeserializePrivateKey(privateKeyBytes)
 }
 
 func HashDirect(message []byte, usePoP bool) ([]byte, error) {
-	return blsRoute.HashDirect(message, usePoP)
+    return blsRoute.HashDirect(message, usePoP)
 }
 
 func HashDirectWithAttempt(message []byte, usePoP bool) ([]byte, uint, error) {
-	return blsRoute.HashDirectWithAttempt(message, usePoP)
+    return blsRoute.HashDirectWithAttempt(message, usePoP)
 }
 
 func HashComposite(message []byte, extraData []byte) ([]byte, error) {
-	return blsRoute.HashComposite(message, extraData)
+    return blsRoute.HashComposite(message, extraData)
 }
 
 func HashDirectFirstStep(message []byte, hashBytes int32) ([]byte, error) {
-	return blsRoute.HashDirectFirstStep(message, hashBytes)
+    return blsRoute.HashDirectFirstStep(message, hashBytes)
 }
 
 func HashCRH(message []byte, hashBytes int32) ([]byte, error) {
-	return blsRoute.HashCRH(message, hashBytes)
+    return blsRoute.HashCRH(message, hashBytes)
 }
 
 func HashCompositeCIP22(message []byte, extraData []byte) ([]byte, uint8, error) {
-	return blsRoute.HashCompositeCIP22(message, extraData)
+    return blsRoute.HashCompositeCIP22(message, extraData)
 }
 
 func CompressSignature(signature []byte) ([]byte, error) {
-	return blsRoute.CompressSignature(signature)
+    return blsRoute.CompressSignature(signature)
 }
 
 func CompressPublickey(pubkey []byte) ([]byte, error) {
-	return blsRoute.CompressPublickey(pubkey)
+    return blsRoute.CompressPublickey(pubkey)
 }
 
 func DeserializePublicKey(publicKeyBytes []byte) (*PublicKey, error) {
-	return blsRoute.DeserializePublicKey(publicKeyBytes)
+    return blsRoute.DeserializePublicKey(publicKeyBytes)
 }
 
 func DeserializePublicKeyCached(publicKeyBytes []byte) (*PublicKey, error) {
-	return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
+    return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
 }
 
 func BatchVerifyEpochs(signedHeaders []*SignedBlockHeader, shouldUseCompositeHasher, shouldUseCIP22 bool) error {
-	return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
+    return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-	return blsRoute.DeserializeSignature(signatureBytes)
+    return blsRoute.DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {
-	return blsRoute.AggregatePublicKeys(publicKeys)
+    return blsRoute.AggregatePublicKeys(publicKeys)
 }
 
 func AggregatePublicKeysSubtract(aggregatedPublicKey *PublicKey, publicKeys []*PublicKey) (*PublicKey, error) {
-	return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
+    return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
 }
 
 func AggregateSignatures(signatures []*Signature) (*Signature, error) {
-	return blsRoute.AggregateSignatures(signatures)
+    return blsRoute.AggregateSignatures(signatures)
 }
 
 func EncodeEpochToBytesCIP22(epochIndex uint16, round uint8, blockHash, parentHash EpochEntropy, maximumNonSigners, maximumValidators uint32, addedPublicKeys []*PublicKey) ([]byte, []byte, error) {
-	return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
+    return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
 }
 
 func EncodeEpochToBytes(epochIndex uint16, maximumNonSigners uint32, addedPublicKeys []*PublicKey) ([]byte, error) {
-	return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
+    return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
 }

--- a/bls/bls_linux.go
+++ b/bls/bls_linux.go
@@ -1,9 +1,10 @@
+//go:build (linux && arm64) || (!android && linux && amd64 && !musl) || (linux && arm && !arm7) || arm7 || (!android && linux && 386 && !musl) || (!android && musl) || (linux && mips) || (linux && mips64) || (linux && mips64le) || (linux && mipsle)
 // +build linux,arm64 !android,linux,amd64,!musl linux,arm,!arm7 arm7 !android,linux,386,!musl !android,musl linux,mips linux,mips64 linux,mips64le linux,mipsle
 
 package bls
 
 import (
-    blsRoute "github.com/celo-org/celo-bls-go-linux/bls"
+	blsRoute "github.com/celo-org/celo-bls-go-linux/bls"
 )
 
 const (
@@ -28,84 +29,84 @@ type PrivateKey = blsRoute.PrivateKey
 type PublicKey = blsRoute.PublicKey
 type Signature = blsRoute.Signature
 type SignedBlockHeader = blsRoute.SignedBlockHeader
-type EpochEntropy  = blsRoute.EpochEntropy
+type EpochEntropy = blsRoute.EpochEntropy
 
 func InitBLSCrypto() {
-    blsRoute.InitBLSCrypto()
+	blsRoute.InitBLSCrypto()
 }
 
 func GeneratePrivateKey() (*PrivateKey, error) {
-    return blsRoute.GeneratePrivateKey()
+	return blsRoute.GeneratePrivateKey()
 }
 
 func DeserializePrivateKey(privateKeyBytes []byte) (*PrivateKey, error) {
-    return blsRoute.DeserializePrivateKey(privateKeyBytes)
+	return blsRoute.DeserializePrivateKey(privateKeyBytes)
 }
 
 func HashDirect(message []byte, usePoP bool) ([]byte, error) {
-    return blsRoute.HashDirect(message, usePoP)
+	return blsRoute.HashDirect(message, usePoP)
 }
 
 func HashDirectWithAttempt(message []byte, usePoP bool) ([]byte, uint, error) {
-    return blsRoute.HashDirectWithAttempt(message, usePoP)
+	return blsRoute.HashDirectWithAttempt(message, usePoP)
 }
 
 func HashComposite(message []byte, extraData []byte) ([]byte, error) {
-    return blsRoute.HashComposite(message, extraData)
+	return blsRoute.HashComposite(message, extraData)
 }
 
 func HashDirectFirstStep(message []byte, hashBytes int32) ([]byte, error) {
-    return blsRoute.HashDirectFirstStep(message, hashBytes)
+	return blsRoute.HashDirectFirstStep(message, hashBytes)
 }
 
 func HashCRH(message []byte, hashBytes int32) ([]byte, error) {
-    return blsRoute.HashCRH(message, hashBytes)
+	return blsRoute.HashCRH(message, hashBytes)
 }
 
 func HashCompositeCIP22(message []byte, extraData []byte) ([]byte, uint8, error) {
-    return blsRoute.HashCompositeCIP22(message, extraData)
+	return blsRoute.HashCompositeCIP22(message, extraData)
 }
 
 func CompressSignature(signature []byte) ([]byte, error) {
-    return blsRoute.CompressSignature(signature)
+	return blsRoute.CompressSignature(signature)
 }
 
 func CompressPublickey(pubkey []byte) ([]byte, error) {
-    return blsRoute.CompressPublickey(pubkey)
+	return blsRoute.CompressPublickey(pubkey)
 }
 
 func DeserializePublicKey(publicKeyBytes []byte) (*PublicKey, error) {
-    return blsRoute.DeserializePublicKey(publicKeyBytes)
+	return blsRoute.DeserializePublicKey(publicKeyBytes)
 }
 
 func DeserializePublicKeyCached(publicKeyBytes []byte) (*PublicKey, error) {
-    return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
+	return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
 }
 
 func BatchVerifyEpochs(signedHeaders []*SignedBlockHeader, shouldUseCompositeHasher, shouldUseCIP22 bool) error {
-    return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
+	return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-    return DeserializeSignature(signatureBytes)
+	return blsRoute.DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {
-    return blsRoute.AggregatePublicKeys(publicKeys)
+	return blsRoute.AggregatePublicKeys(publicKeys)
 }
 
 func AggregatePublicKeysSubtract(aggregatedPublicKey *PublicKey, publicKeys []*PublicKey) (*PublicKey, error) {
-    return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
+	return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
 }
 
 func AggregateSignatures(signatures []*Signature) (*Signature, error) {
-    return blsRoute.AggregateSignatures(signatures)
+	return blsRoute.AggregateSignatures(signatures)
 }
 
 func EncodeEpochToBytesCIP22(epochIndex uint16, round uint8, blockHash, parentHash EpochEntropy, maximumNonSigners, maximumValidators uint32, addedPublicKeys []*PublicKey) ([]byte, []byte, error) {
-    return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
+	return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
 }
 
 func EncodeEpochToBytes(epochIndex uint16, maximumNonSigners uint32, addedPublicKeys []*PublicKey) ([]byte, error) {
-    return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
+	return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
 }

--- a/bls/bls_macos.go
+++ b/bls/bls_macos.go
@@ -1,10 +1,9 @@
-//go:build (darwin && amd64 && !ios) || (darwin && arm64 && !ios)
 // +build darwin,amd64,!ios darwin,arm64,!ios
 
 package bls
 
 import (
-	blsRoute "github.com/celo-org/celo-bls-go-macos/bls"
+    blsRoute "github.com/celo-org/celo-bls-go-macos/bls"
 )
 
 const (
@@ -32,81 +31,81 @@ type SignedBlockHeader = blsRoute.SignedBlockHeader
 type EpochEntropy = blsRoute.EpochEntropy
 
 func InitBLSCrypto() {
-	blsRoute.InitBLSCrypto()
+    blsRoute.InitBLSCrypto()
 }
 
 func GeneratePrivateKey() (*PrivateKey, error) {
-	return blsRoute.GeneratePrivateKey()
+    return blsRoute.GeneratePrivateKey()
 }
 
 func DeserializePrivateKey(privateKeyBytes []byte) (*PrivateKey, error) {
-	return blsRoute.DeserializePrivateKey(privateKeyBytes)
+    return blsRoute.DeserializePrivateKey(privateKeyBytes)
 }
 
 func HashDirect(message []byte, usePoP bool) ([]byte, error) {
-	return blsRoute.HashDirect(message, usePoP)
+    return blsRoute.HashDirect(message, usePoP)
 }
 
 func HashDirectWithAttempt(message []byte, usePoP bool) ([]byte, uint, error) {
-	return blsRoute.HashDirectWithAttempt(message, usePoP)
+    return blsRoute.HashDirectWithAttempt(message, usePoP)
 }
 
 func HashComposite(message []byte, extraData []byte) ([]byte, error) {
-	return blsRoute.HashComposite(message, extraData)
+    return blsRoute.HashComposite(message, extraData)
 }
 
 func HashDirectFirstStep(message []byte, hashBytes int32) ([]byte, error) {
-	return blsRoute.HashDirectFirstStep(message, hashBytes)
+    return blsRoute.HashDirectFirstStep(message, hashBytes)
 }
 
 func HashCRH(message []byte, hashBytes int32) ([]byte, error) {
-	return blsRoute.HashCRH(message, hashBytes)
+    return blsRoute.HashCRH(message, hashBytes)
 }
 
 func HashCompositeCIP22(message []byte, extraData []byte) ([]byte, uint8, error) {
-	return blsRoute.HashCompositeCIP22(message, extraData)
+    return blsRoute.HashCompositeCIP22(message, extraData)
 }
 
 func CompressSignature(signature []byte) ([]byte, error) {
-	return blsRoute.CompressSignature(signature)
+    return blsRoute.CompressSignature(signature)
 }
 
 func CompressPublickey(pubkey []byte) ([]byte, error) {
-	return blsRoute.CompressPublickey(pubkey)
+    return blsRoute.CompressPublickey(pubkey)
 }
 
 func DeserializePublicKey(publicKeyBytes []byte) (*PublicKey, error) {
-	return blsRoute.DeserializePublicKey(publicKeyBytes)
+    return blsRoute.DeserializePublicKey(publicKeyBytes)
 }
 
 func DeserializePublicKeyCached(publicKeyBytes []byte) (*PublicKey, error) {
-	return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
+    return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
 }
 
 func BatchVerifyEpochs(signedHeaders []*SignedBlockHeader, shouldUseCompositeHasher, shouldUseCIP22 bool) error {
-	return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
+    return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-	return blsRoute.DeserializeSignature(signatureBytes)
+    return blsRoute.DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {
-	return blsRoute.AggregatePublicKeys(publicKeys)
+    return blsRoute.AggregatePublicKeys(publicKeys)
 }
 
 func AggregatePublicKeysSubtract(aggregatedPublicKey *PublicKey, publicKeys []*PublicKey) (*PublicKey, error) {
-	return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
+    return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
 }
 
 func AggregateSignatures(signatures []*Signature) (*Signature, error) {
-	return blsRoute.AggregateSignatures(signatures)
+    return blsRoute.AggregateSignatures(signatures)
 }
 
 func EncodeEpochToBytesCIP22(epochIndex uint16, round uint8, blockHash, parentHash EpochEntropy, maximumNonSigners, maximumValidators uint32, addedPublicKeys []*PublicKey) ([]byte, []byte, error) {
-	return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
+    return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
 }
 
 func EncodeEpochToBytes(epochIndex uint16, maximumNonSigners uint32, addedPublicKeys []*PublicKey) ([]byte, error) {
-	return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
+    return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
 }

--- a/bls/bls_macos.go
+++ b/bls/bls_macos.go
@@ -1,9 +1,10 @@
+//go:build (darwin && amd64 && !ios) || (darwin && arm64 && !ios)
 // +build darwin,amd64,!ios darwin,arm64,!ios
 
 package bls
 
 import (
-    blsRoute "github.com/celo-org/celo-bls-go-macos/bls"
+	blsRoute "github.com/celo-org/celo-bls-go-macos/bls"
 )
 
 const (
@@ -28,84 +29,84 @@ type PrivateKey = blsRoute.PrivateKey
 type PublicKey = blsRoute.PublicKey
 type Signature = blsRoute.Signature
 type SignedBlockHeader = blsRoute.SignedBlockHeader
-type EpochEntropy  = blsRoute.EpochEntropy
+type EpochEntropy = blsRoute.EpochEntropy
 
 func InitBLSCrypto() {
-    blsRoute.InitBLSCrypto()
+	blsRoute.InitBLSCrypto()
 }
 
 func GeneratePrivateKey() (*PrivateKey, error) {
-    return blsRoute.GeneratePrivateKey()
+	return blsRoute.GeneratePrivateKey()
 }
 
 func DeserializePrivateKey(privateKeyBytes []byte) (*PrivateKey, error) {
-    return blsRoute.DeserializePrivateKey(privateKeyBytes)
+	return blsRoute.DeserializePrivateKey(privateKeyBytes)
 }
 
 func HashDirect(message []byte, usePoP bool) ([]byte, error) {
-    return blsRoute.HashDirect(message, usePoP)
+	return blsRoute.HashDirect(message, usePoP)
 }
 
 func HashDirectWithAttempt(message []byte, usePoP bool) ([]byte, uint, error) {
-    return blsRoute.HashDirectWithAttempt(message, usePoP)
+	return blsRoute.HashDirectWithAttempt(message, usePoP)
 }
 
 func HashComposite(message []byte, extraData []byte) ([]byte, error) {
-    return blsRoute.HashComposite(message, extraData)
+	return blsRoute.HashComposite(message, extraData)
 }
 
 func HashDirectFirstStep(message []byte, hashBytes int32) ([]byte, error) {
-    return blsRoute.HashDirectFirstStep(message, hashBytes)
+	return blsRoute.HashDirectFirstStep(message, hashBytes)
 }
 
 func HashCRH(message []byte, hashBytes int32) ([]byte, error) {
-    return blsRoute.HashCRH(message, hashBytes)
+	return blsRoute.HashCRH(message, hashBytes)
 }
 
 func HashCompositeCIP22(message []byte, extraData []byte) ([]byte, uint8, error) {
-    return blsRoute.HashCompositeCIP22(message, extraData)
+	return blsRoute.HashCompositeCIP22(message, extraData)
 }
 
 func CompressSignature(signature []byte) ([]byte, error) {
-    return blsRoute.CompressSignature(signature)
+	return blsRoute.CompressSignature(signature)
 }
 
 func CompressPublickey(pubkey []byte) ([]byte, error) {
-    return blsRoute.CompressPublickey(pubkey)
+	return blsRoute.CompressPublickey(pubkey)
 }
 
 func DeserializePublicKey(publicKeyBytes []byte) (*PublicKey, error) {
-    return blsRoute.DeserializePublicKey(publicKeyBytes)
+	return blsRoute.DeserializePublicKey(publicKeyBytes)
 }
 
 func DeserializePublicKeyCached(publicKeyBytes []byte) (*PublicKey, error) {
-    return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
+	return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
 }
 
 func BatchVerifyEpochs(signedHeaders []*SignedBlockHeader, shouldUseCompositeHasher, shouldUseCIP22 bool) error {
-    return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
+	return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-    return DeserializeSignature(signatureBytes)
+	return blsRoute.DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {
-    return blsRoute.AggregatePublicKeys(publicKeys)
+	return blsRoute.AggregatePublicKeys(publicKeys)
 }
 
 func AggregatePublicKeysSubtract(aggregatedPublicKey *PublicKey, publicKeys []*PublicKey) (*PublicKey, error) {
-    return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
+	return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
 }
 
 func AggregateSignatures(signatures []*Signature) (*Signature, error) {
-    return blsRoute.AggregateSignatures(signatures)
+	return blsRoute.AggregateSignatures(signatures)
 }
 
 func EncodeEpochToBytesCIP22(epochIndex uint16, round uint8, blockHash, parentHash EpochEntropy, maximumNonSigners, maximumValidators uint32, addedPublicKeys []*PublicKey) ([]byte, []byte, error) {
-    return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
+	return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
 }
 
 func EncodeEpochToBytes(epochIndex uint16, maximumNonSigners uint32, addedPublicKeys []*PublicKey) ([]byte, error) {
-    return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
+	return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
 }

--- a/bls/bls_other.go
+++ b/bls/bls_other.go
@@ -1,10 +1,9 @@
-//go:build s390x
 // +build s390x
 
 package bls
 
 import (
-	blsRoute "github.com/celo-org/celo-bls-go-other/bls"
+    blsRoute "github.com/celo-org/celo-bls-go-other/bls"
 )
 
 const (
@@ -32,81 +31,81 @@ type SignedBlockHeader = blsRoute.SignedBlockHeader
 type EpochEntropy = blsRoute.EpochEntropy
 
 func InitBLSCrypto() {
-	blsRoute.InitBLSCrypto()
+    blsRoute.InitBLSCrypto()
 }
 
 func GeneratePrivateKey() (*PrivateKey, error) {
-	return blsRoute.GeneratePrivateKey()
+    return blsRoute.GeneratePrivateKey()
 }
 
 func DeserializePrivateKey(privateKeyBytes []byte) (*PrivateKey, error) {
-	return blsRoute.DeserializePrivateKey(privateKeyBytes)
+    return blsRoute.DeserializePrivateKey(privateKeyBytes)
 }
 
 func HashDirect(message []byte, usePoP bool) ([]byte, error) {
-	return blsRoute.HashDirect(message, usePoP)
+    return blsRoute.HashDirect(message, usePoP)
 }
 
 func HashDirectWithAttempt(message []byte, usePoP bool) ([]byte, uint, error) {
-	return blsRoute.HashDirectWithAttempt(message, usePoP)
+    return blsRoute.HashDirectWithAttempt(message, usePoP)
 }
 
 func HashComposite(message []byte, extraData []byte) ([]byte, error) {
-	return blsRoute.HashComposite(message, extraData)
+    return blsRoute.HashComposite(message, extraData)
 }
 
 func HashDirectFirstStep(message []byte, hashBytes int32) ([]byte, error) {
-	return blsRoute.HashDirectFirstStep(message, hashBytes)
+    return blsRoute.HashDirectFirstStep(message, hashBytes)
 }
 
 func HashCRH(message []byte, hashBytes int32) ([]byte, error) {
-	return blsRoute.HashCRH(message, hashBytes)
+    return blsRoute.HashCRH(message, hashBytes)
 }
 
 func HashCompositeCIP22(message []byte, extraData []byte) ([]byte, uint8, error) {
-	return blsRoute.HashCompositeCIP22(message, extraData)
+    return blsRoute.HashCompositeCIP22(message, extraData)
 }
 
 func CompressSignature(signature []byte) ([]byte, error) {
-	return blsRoute.CompressSignature(signature)
+    return blsRoute.CompressSignature(signature)
 }
 
 func CompressPublickey(pubkey []byte) ([]byte, error) {
-	return blsRoute.CompressPublickey(pubkey)
+    return blsRoute.CompressPublickey(pubkey)
 }
 
 func DeserializePublicKey(publicKeyBytes []byte) (*PublicKey, error) {
-	return blsRoute.DeserializePublicKey(publicKeyBytes)
+    return blsRoute.DeserializePublicKey(publicKeyBytes)
 }
 
 func DeserializePublicKeyCached(publicKeyBytes []byte) (*PublicKey, error) {
-	return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
+    return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
 }
 
 func BatchVerifyEpochs(signedHeaders []*SignedBlockHeader, shouldUseCompositeHasher, shouldUseCIP22 bool) error {
-	return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
+    return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-	return blsRoute.DeserializeSignature(signatureBytes)
+    return blsRoute.DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {
-	return blsRoute.AggregatePublicKeys(publicKeys)
+    return blsRoute.AggregatePublicKeys(publicKeys)
 }
 
 func AggregatePublicKeysSubtract(aggregatedPublicKey *PublicKey, publicKeys []*PublicKey) (*PublicKey, error) {
-	return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
+    return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
 }
 
 func AggregateSignatures(signatures []*Signature) (*Signature, error) {
-	return blsRoute.AggregateSignatures(signatures)
+    return blsRoute.AggregateSignatures(signatures)
 }
 
 func EncodeEpochToBytesCIP22(epochIndex uint16, round uint8, blockHash, parentHash EpochEntropy, maximumNonSigners, maximumValidators uint32, addedPublicKeys []*PublicKey) ([]byte, []byte, error) {
-	return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
+    return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
 }
 
 func EncodeEpochToBytes(epochIndex uint16, maximumNonSigners uint32, addedPublicKeys []*PublicKey) ([]byte, error) {
-	return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
+    return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
 }

--- a/bls/bls_other.go
+++ b/bls/bls_other.go
@@ -1,9 +1,10 @@
+//go:build s390x
 // +build s390x
 
 package bls
 
 import (
-    blsRoute "github.com/celo-org/celo-bls-go-other/bls"
+	blsRoute "github.com/celo-org/celo-bls-go-other/bls"
 )
 
 const (
@@ -28,84 +29,84 @@ type PrivateKey = blsRoute.PrivateKey
 type PublicKey = blsRoute.PublicKey
 type Signature = blsRoute.Signature
 type SignedBlockHeader = blsRoute.SignedBlockHeader
-type EpochEntropy  = blsRoute.EpochEntropy
+type EpochEntropy = blsRoute.EpochEntropy
 
 func InitBLSCrypto() {
-    blsRoute.InitBLSCrypto()
+	blsRoute.InitBLSCrypto()
 }
 
 func GeneratePrivateKey() (*PrivateKey, error) {
-    return blsRoute.GeneratePrivateKey()
+	return blsRoute.GeneratePrivateKey()
 }
 
 func DeserializePrivateKey(privateKeyBytes []byte) (*PrivateKey, error) {
-    return blsRoute.DeserializePrivateKey(privateKeyBytes)
+	return blsRoute.DeserializePrivateKey(privateKeyBytes)
 }
 
 func HashDirect(message []byte, usePoP bool) ([]byte, error) {
-    return blsRoute.HashDirect(message, usePoP)
+	return blsRoute.HashDirect(message, usePoP)
 }
 
 func HashDirectWithAttempt(message []byte, usePoP bool) ([]byte, uint, error) {
-    return blsRoute.HashDirectWithAttempt(message, usePoP)
+	return blsRoute.HashDirectWithAttempt(message, usePoP)
 }
 
 func HashComposite(message []byte, extraData []byte) ([]byte, error) {
-    return blsRoute.HashComposite(message, extraData)
+	return blsRoute.HashComposite(message, extraData)
 }
 
 func HashDirectFirstStep(message []byte, hashBytes int32) ([]byte, error) {
-    return blsRoute.HashDirectFirstStep(message, hashBytes)
+	return blsRoute.HashDirectFirstStep(message, hashBytes)
 }
 
 func HashCRH(message []byte, hashBytes int32) ([]byte, error) {
-    return blsRoute.HashCRH(message, hashBytes)
+	return blsRoute.HashCRH(message, hashBytes)
 }
 
 func HashCompositeCIP22(message []byte, extraData []byte) ([]byte, uint8, error) {
-    return blsRoute.HashCompositeCIP22(message, extraData)
+	return blsRoute.HashCompositeCIP22(message, extraData)
 }
 
 func CompressSignature(signature []byte) ([]byte, error) {
-    return blsRoute.CompressSignature(signature)
+	return blsRoute.CompressSignature(signature)
 }
 
 func CompressPublickey(pubkey []byte) ([]byte, error) {
-    return blsRoute.CompressPublickey(pubkey)
+	return blsRoute.CompressPublickey(pubkey)
 }
 
 func DeserializePublicKey(publicKeyBytes []byte) (*PublicKey, error) {
-    return blsRoute.DeserializePublicKey(publicKeyBytes)
+	return blsRoute.DeserializePublicKey(publicKeyBytes)
 }
 
 func DeserializePublicKeyCached(publicKeyBytes []byte) (*PublicKey, error) {
-    return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
+	return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
 }
 
 func BatchVerifyEpochs(signedHeaders []*SignedBlockHeader, shouldUseCompositeHasher, shouldUseCIP22 bool) error {
-    return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
+	return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-    return DeserializeSignature(signatureBytes)
+	return blsRoute.DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {
-    return blsRoute.AggregatePublicKeys(publicKeys)
+	return blsRoute.AggregatePublicKeys(publicKeys)
 }
 
 func AggregatePublicKeysSubtract(aggregatedPublicKey *PublicKey, publicKeys []*PublicKey) (*PublicKey, error) {
-    return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
+	return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
 }
 
 func AggregateSignatures(signatures []*Signature) (*Signature, error) {
-    return blsRoute.AggregateSignatures(signatures)
+	return blsRoute.AggregateSignatures(signatures)
 }
 
 func EncodeEpochToBytesCIP22(epochIndex uint16, round uint8, blockHash, parentHash EpochEntropy, maximumNonSigners, maximumValidators uint32, addedPublicKeys []*PublicKey) ([]byte, []byte, error) {
-    return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
+	return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
 }
 
 func EncodeEpochToBytes(epochIndex uint16, maximumNonSigners uint32, addedPublicKeys []*PublicKey) ([]byte, error) {
-    return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
+	return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
 }

--- a/bls/bls_windows.go
+++ b/bls/bls_windows.go
@@ -1,10 +1,9 @@
-//go:build (windows && 386) || (windows && amd64)
 // +build windows,386 windows,amd64
 
 package bls
 
 import (
-	blsRoute "github.com/celo-org/celo-bls-go-windows/bls"
+    blsRoute "github.com/celo-org/celo-bls-go-windows/bls"
 )
 
 const (
@@ -32,81 +31,81 @@ type SignedBlockHeader = blsRoute.SignedBlockHeader
 type EpochEntropy = blsRoute.EpochEntropy
 
 func InitBLSCrypto() {
-	blsRoute.InitBLSCrypto()
+    blsRoute.InitBLSCrypto()
 }
 
 func GeneratePrivateKey() (*PrivateKey, error) {
-	return blsRoute.GeneratePrivateKey()
+    return blsRoute.GeneratePrivateKey()
 }
 
 func DeserializePrivateKey(privateKeyBytes []byte) (*PrivateKey, error) {
-	return blsRoute.DeserializePrivateKey(privateKeyBytes)
+    return blsRoute.DeserializePrivateKey(privateKeyBytes)
 }
 
 func HashDirect(message []byte, usePoP bool) ([]byte, error) {
-	return blsRoute.HashDirect(message, usePoP)
+    return blsRoute.HashDirect(message, usePoP)
 }
 
 func HashDirectWithAttempt(message []byte, usePoP bool) ([]byte, uint, error) {
-	return blsRoute.HashDirectWithAttempt(message, usePoP)
+    return blsRoute.HashDirectWithAttempt(message, usePoP)
 }
 
 func HashComposite(message []byte, extraData []byte) ([]byte, error) {
-	return blsRoute.HashComposite(message, extraData)
+    return blsRoute.HashComposite(message, extraData)
 }
 
 func HashDirectFirstStep(message []byte, hashBytes int32) ([]byte, error) {
-	return blsRoute.HashDirectFirstStep(message, hashBytes)
+    return blsRoute.HashDirectFirstStep(message, hashBytes)
 }
 
 func HashCRH(message []byte, hashBytes int32) ([]byte, error) {
-	return blsRoute.HashCRH(message, hashBytes)
+    return blsRoute.HashCRH(message, hashBytes)
 }
 
 func HashCompositeCIP22(message []byte, extraData []byte) ([]byte, uint8, error) {
-	return blsRoute.HashCompositeCIP22(message, extraData)
+    return blsRoute.HashCompositeCIP22(message, extraData)
 }
 
 func CompressSignature(signature []byte) ([]byte, error) {
-	return blsRoute.CompressSignature(signature)
+    return blsRoute.CompressSignature(signature)
 }
 
 func CompressPublickey(pubkey []byte) ([]byte, error) {
-	return blsRoute.CompressPublickey(pubkey)
+    return blsRoute.CompressPublickey(pubkey)
 }
 
 func DeserializePublicKey(publicKeyBytes []byte) (*PublicKey, error) {
-	return blsRoute.DeserializePublicKey(publicKeyBytes)
+    return blsRoute.DeserializePublicKey(publicKeyBytes)
 }
 
 func DeserializePublicKeyCached(publicKeyBytes []byte) (*PublicKey, error) {
-	return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
+    return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
 }
 
 func BatchVerifyEpochs(signedHeaders []*SignedBlockHeader, shouldUseCompositeHasher, shouldUseCIP22 bool) error {
-	return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
+    return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-	return blsRoute.DeserializeSignature(signatureBytes)
+    return blsRoute.DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {
-	return blsRoute.AggregatePublicKeys(publicKeys)
+    return blsRoute.AggregatePublicKeys(publicKeys)
 }
 
 func AggregatePublicKeysSubtract(aggregatedPublicKey *PublicKey, publicKeys []*PublicKey) (*PublicKey, error) {
-	return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
+    return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
 }
 
 func AggregateSignatures(signatures []*Signature) (*Signature, error) {
-	return blsRoute.AggregateSignatures(signatures)
+    return blsRoute.AggregateSignatures(signatures)
 }
 
 func EncodeEpochToBytesCIP22(epochIndex uint16, round uint8, blockHash, parentHash EpochEntropy, maximumNonSigners, maximumValidators uint32, addedPublicKeys []*PublicKey) ([]byte, []byte, error) {
-	return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
+    return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
 }
 
 func EncodeEpochToBytes(epochIndex uint16, maximumNonSigners uint32, addedPublicKeys []*PublicKey) ([]byte, error) {
-	return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
+    return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
 }

--- a/bls/bls_windows.go
+++ b/bls/bls_windows.go
@@ -1,9 +1,10 @@
+//go:build (windows && 386) || (windows && amd64)
 // +build windows,386 windows,amd64
 
 package bls
 
 import (
-    blsRoute "github.com/celo-org/celo-bls-go-windows/bls"
+	blsRoute "github.com/celo-org/celo-bls-go-windows/bls"
 )
 
 const (
@@ -28,84 +29,84 @@ type PrivateKey = blsRoute.PrivateKey
 type PublicKey = blsRoute.PublicKey
 type Signature = blsRoute.Signature
 type SignedBlockHeader = blsRoute.SignedBlockHeader
-type EpochEntropy  = blsRoute.EpochEntropy
+type EpochEntropy = blsRoute.EpochEntropy
 
 func InitBLSCrypto() {
-    blsRoute.InitBLSCrypto()
+	blsRoute.InitBLSCrypto()
 }
 
 func GeneratePrivateKey() (*PrivateKey, error) {
-    return blsRoute.GeneratePrivateKey()
+	return blsRoute.GeneratePrivateKey()
 }
 
 func DeserializePrivateKey(privateKeyBytes []byte) (*PrivateKey, error) {
-    return blsRoute.DeserializePrivateKey(privateKeyBytes)
+	return blsRoute.DeserializePrivateKey(privateKeyBytes)
 }
 
 func HashDirect(message []byte, usePoP bool) ([]byte, error) {
-    return blsRoute.HashDirect(message, usePoP)
+	return blsRoute.HashDirect(message, usePoP)
 }
 
 func HashDirectWithAttempt(message []byte, usePoP bool) ([]byte, uint, error) {
-    return blsRoute.HashDirectWithAttempt(message, usePoP)
+	return blsRoute.HashDirectWithAttempt(message, usePoP)
 }
 
 func HashComposite(message []byte, extraData []byte) ([]byte, error) {
-    return blsRoute.HashComposite(message, extraData)
+	return blsRoute.HashComposite(message, extraData)
 }
 
 func HashDirectFirstStep(message []byte, hashBytes int32) ([]byte, error) {
-    return blsRoute.HashDirectFirstStep(message, hashBytes)
+	return blsRoute.HashDirectFirstStep(message, hashBytes)
 }
 
 func HashCRH(message []byte, hashBytes int32) ([]byte, error) {
-    return blsRoute.HashCRH(message, hashBytes)
+	return blsRoute.HashCRH(message, hashBytes)
 }
 
 func HashCompositeCIP22(message []byte, extraData []byte) ([]byte, uint8, error) {
-    return blsRoute.HashCompositeCIP22(message, extraData)
+	return blsRoute.HashCompositeCIP22(message, extraData)
 }
 
 func CompressSignature(signature []byte) ([]byte, error) {
-    return blsRoute.CompressSignature(signature)
+	return blsRoute.CompressSignature(signature)
 }
 
 func CompressPublickey(pubkey []byte) ([]byte, error) {
-    return blsRoute.CompressPublickey(pubkey)
+	return blsRoute.CompressPublickey(pubkey)
 }
 
 func DeserializePublicKey(publicKeyBytes []byte) (*PublicKey, error) {
-    return blsRoute.DeserializePublicKey(publicKeyBytes)
+	return blsRoute.DeserializePublicKey(publicKeyBytes)
 }
 
 func DeserializePublicKeyCached(publicKeyBytes []byte) (*PublicKey, error) {
-    return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
+	return blsRoute.DeserializePublicKeyCached(publicKeyBytes)
 }
 
 func BatchVerifyEpochs(signedHeaders []*SignedBlockHeader, shouldUseCompositeHasher, shouldUseCIP22 bool) error {
-    return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
+	return blsRoute.BatchVerifyEpochs(signedHeaders, shouldUseCompositeHasher, shouldUseCIP22)
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-    return DeserializeSignature(signatureBytes)
+	return blsRoute.DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {
-    return blsRoute.AggregatePublicKeys(publicKeys)
+	return blsRoute.AggregatePublicKeys(publicKeys)
 }
 
 func AggregatePublicKeysSubtract(aggregatedPublicKey *PublicKey, publicKeys []*PublicKey) (*PublicKey, error) {
-    return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
+	return blsRoute.AggregatePublicKeysSubtract(aggregatedPublicKey, publicKeys)
 }
 
 func AggregateSignatures(signatures []*Signature) (*Signature, error) {
-    return blsRoute.AggregateSignatures(signatures)
+	return blsRoute.AggregateSignatures(signatures)
 }
 
 func EncodeEpochToBytesCIP22(epochIndex uint16, round uint8, blockHash, parentHash EpochEntropy, maximumNonSigners, maximumValidators uint32, addedPublicKeys []*PublicKey) ([]byte, []byte, error) {
-    return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
+	return blsRoute.EncodeEpochToBytesCIP22(epochIndex, round, blockHash, parentHash, maximumNonSigners, maximumValidators, addedPublicKeys)
 }
 
 func EncodeEpochToBytes(epochIndex uint16, maximumNonSigners uint32, addedPublicKeys []*PublicKey) ([]byte, error) {
-    return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
+	return blsRoute.EncodeEpochToBytes(epochIndex, maximumNonSigners, addedPublicKeys)
 }

--- a/cmd/distribute/distribute.go
+++ b/cmd/distribute/distribute.go
@@ -15,13 +15,17 @@ const LIB_NAME = "libbls_snark_sys.a"
 const LIB_WINDOWS_NAME = "bls_snark_sys.lib"
 
 type Platform struct {
-	Name string
-	BuildDirective string
+	Name             string
+	BuildDirective   string
 	LinkageDirective string
-	LibDirectories []string
+	LibDirectories   []string
 }
 
 func main() {
+	// First two args should be the source directory and platforms configuration.
+	// * Source directory: Should be the repository root (i.e. $PWD if in the root).
+	// * Platforms config: A JSON file indicating which platforms to build
+	//   (e.g. $PWD/platforms/platforms.json)
 	sourceDir, platformsPath := os.Args[1], os.Args[2]
 	platformsDirPath := path.Join(sourceDir, "platforms")
 	platformsContent, err := ioutil.ReadFile(platformsPath)

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/celo-org/celo-bls-go
 go 1.12
 
 require (
-	github.com/celo-org/celo-bls-go-linux	v0.3.0
-	github.com/celo-org/celo-bls-go-macos	v0.3.0
-	github.com/celo-org/celo-bls-go-android	v0.3.0
-	github.com/celo-org/celo-bls-go-ios	v0.3.0
-	github.com/celo-org/celo-bls-go-other	v0.3.0
+	github.com/celo-org/celo-bls-go-linux	v0.3.1-alpha
+	github.com/celo-org/celo-bls-go-macos	v0.3.1-alpha
+	github.com/celo-org/celo-bls-go-android	v0.3.1-alpha
+	github.com/celo-org/celo-bls-go-ios	v0.3.1-alpha
+	github.com/celo-org/celo-bls-go-other	v0.3.1-alpha
 )

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/celo-org/celo-bls-go-android v0.3.0 h1:sqTbRSQQHs+mQnB7oPBrpJGVXRYyBt2hbEeRBwvRgZc=
+github.com/celo-org/celo-bls-go-android v0.3.0/go.mod h1:cFgtFRH8+6x5b+EyG5SqniXY3aKd03NBSGDgITscX34=
+github.com/celo-org/celo-bls-go-ios v0.3.0 h1:MJYYbpDL5AUBJ/doMgST4F6xKMfWZnjmUH8HBBqJEsQ=
+github.com/celo-org/celo-bls-go-ios v0.3.0/go.mod h1:eaSoMpx29YV5oF7jXVChzJpNfxeZHnAa8G4PjL5CyW0=
+github.com/celo-org/celo-bls-go-linux v0.3.0 h1:JkSFuiSn6pdoqIWZu3BDUn6dsB99rFAn12/pwBYkm5c=
+github.com/celo-org/celo-bls-go-linux v0.3.0/go.mod h1:DVpJadg22OrxBtMb0ub6iNVdqDBL/r6EDdWVAA0bHa0=
+github.com/celo-org/celo-bls-go-macos v0.3.0 h1:JRx9P/3fE/4Sd9yZ0LjdVM149E/EG/3oT5JcWJmIoUc=
+github.com/celo-org/celo-bls-go-macos v0.3.0/go.mod h1:mYPuRqGMVxj6yZUeL6Q6ggtP52HPBS1jz+FvBPXQ7QA=
+github.com/celo-org/celo-bls-go-other v0.3.0 h1:eWJPFeqF+iEuoa9hSmO+SraYCSr7lrZLBFN4uKwXsLk=
+github.com/celo-org/celo-bls-go-other v0.3.0/go.mod h1:tNxZNfekzyT7TdYQbyNPhkfpcYtA3KCU/IKX5FNxM/U=

--- a/platforms/bls_router.go.template
+++ b/platforms/bls_router.go.template
@@ -28,7 +28,7 @@ type PrivateKey = blsRoute.PrivateKey
 type PublicKey = blsRoute.PublicKey
 type Signature = blsRoute.Signature
 type SignedBlockHeader = blsRoute.SignedBlockHeader
-type EpochEntropy  = blsRoute.EpochEntropy
+type EpochEntropy = blsRoute.EpochEntropy
 
 func InitBLSCrypto() {
     blsRoute.InitBLSCrypto()

--- a/platforms/bls_router.go.template
+++ b/platforms/bls_router.go.template
@@ -87,7 +87,7 @@ func BatchVerifyEpochs(signedHeaders []*SignedBlockHeader, shouldUseCompositeHas
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-    return DeserializeSignature(signatureBytes)
+    return blsRoute.DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {

--- a/scripts/push_and_tag.sh
+++ b/scripts/push_and_tag.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -ex
+set -ex
 
 TAG=$1
 
@@ -14,7 +15,7 @@ for platform in ${platforms[@]}; do
   git init
   git add .
   git commit -m"sync master"
-  git remote add origin https://github.com/celo-org/celo-bls-go-$platform
+  git remote add origin git@github.com:celo-org/celo-bls-go-$platform.git
   git push -f origin master
   push_tag $TAG
   rm -rf .git

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,14 +4,9 @@ DIRECTORY=./libs
 if [[ -d "$DIRECTORY" ]]
 then
     echo "$DIRECTORY exists on your filesystem. Delete it and run the script again."
-    exit 0
+    exit 1
 fi
 
-if [[ ! -z $CIRCLE_SHA1 && $(git log --format=oneline -n 1 $CIRCLE_SHA1) != *"BUNDLE"* ]]; then
-  echo "Not local and commit message doesn't contain BUNDLE, building only linux."
-  source `dirname $0`/release_linux.sh
-  exit 0
-fi
 pushd celo-bls-snark-rs/crates/bls-snark-sys
 
 export RUSTFLAGS="-Ccodegen-units=1"

--- a/scripts/release_linux.sh
+++ b/scripts/release_linux.sh
@@ -4,7 +4,7 @@ DIRECTORY=./libs
 if [[ -d "$DIRECTORY" ]]
 then
     echo "$DIRECTORY exists on your filesystem. Delete it and run the script again."
-    exit 0
+    exit 1
 fi
 
 pushd celo-bls-snark-rs/crates/bls-snark-sys

--- a/scripts/run_distribute_in_ci.sh
+++ b/scripts/run_distribute_in_ci.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -e
-
-if [[ ! -z $CIRCLE_SHA1 && $(git log --format=oneline -n 1 $CIRCLE_SHA1) != *"BUNDLE"* ]]; then
-  echo "Not local and commit message doesn't contain BUNDLE, distributing only linux."
-  go run cmd/distribute/distribute.go . ./platforms/platforms_linux.json
-  exit 0
-fi
-
-go run cmd/distribute/distribute.go . ./platforms/platforms.json


### PR DESCRIPTION
## Description

In the course of testing an upgrade to celo-bls-go v0.3.0 in celo-blockchain, I discovered that the
DeserializeSignature function has an infinite loop because it called itself, instead of the method
with the same name on the `blsRoute` object.

This PR addresses that issue, fixing the infinite loop.
