### PR TITLE
Fix infinite recursion in DeserializeSignature

### DIFF
--- a/platforms/bls_router.go.template
+++ b/platforms/bls_router.go.template
@@ -92,7 +92,7 @@ func BatchVerifyStrict(batches []*Batch, shouldUseCompositeHasher, shouldUseCIP2
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-	return DeserializeSignature(signatureBytes)
+	return blsRoute.DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {


### PR DESCRIPTION
Fixes the infinite recursion in DeserializeSignature, fixed previously in https://github.com/celo-org/celo-bls-go/pull/31 and reintroduced in https://github.com/celo-org/celo-bls-go/pull/32.