### PR TITLE
Fix templates for DeserializeSignature

### DIFF
--- a/bls/bls_android.go
+++ b/bls/bls_android.go
@@ -92,7 +92,7 @@ func BatchVerifyStrict(batches []*Batch, shouldUseCompositeHasher, shouldUseCIP2
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-	return DeserializeSignature(signatureBytes)
+	return blsRoute.DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {

--- a/bls/bls_ios.go
+++ b/bls/bls_ios.go
@@ -92,7 +92,7 @@ func BatchVerifyStrict(batches []*Batch, shouldUseCompositeHasher, shouldUseCIP2
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-	return DeserializeSignature(signatureBytes)
+	return blsRoute.DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {

--- a/bls/bls_linux.go
+++ b/bls/bls_linux.go
@@ -92,7 +92,7 @@ func BatchVerifyStrict(batches []*Batch, shouldUseCompositeHasher, shouldUseCIP2
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-	return DeserializeSignature(signatureBytes)
+	return blsRoute.DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {

--- a/bls/bls_macos.go
+++ b/bls/bls_macos.go
@@ -92,7 +92,7 @@ func BatchVerifyStrict(batches []*Batch, shouldUseCompositeHasher, shouldUseCIP2
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-	return DeserializeSignature(signatureBytes)
+	return blsRoute.DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {

--- a/bls/bls_other.go
+++ b/bls/bls_other.go
@@ -92,7 +92,7 @@ func BatchVerifyStrict(batches []*Batch, shouldUseCompositeHasher, shouldUseCIP2
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-	return DeserializeSignature(signatureBytes)
+	return blsRoute.DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {

--- a/bls/bls_windows.go
+++ b/bls/bls_windows.go
@@ -92,7 +92,7 @@ func BatchVerifyStrict(batches []*Batch, shouldUseCompositeHasher, shouldUseCIP2
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-	return DeserializeSignature(signatureBytes)
+	return blsRoute.DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module github.com/celo-org/celo-bls-go
 go 1.12
 
 require (
-	github.com/celo-org/celo-bls-go-android v0.6.1
-	github.com/celo-org/celo-bls-go-ios v0.6.1
-	github.com/celo-org/celo-bls-go-linux v0.6.1
-	github.com/celo-org/celo-bls-go-macos v0.6.1
-	github.com/celo-org/celo-bls-go-other v0.6.1
-	github.com/celo-org/celo-bls-go-windows v0.6.1
+	github.com/celo-org/celo-bls-go-linux	v0.6.2
+	github.com/celo-org/celo-bls-go-macos	v0.6.2
+	github.com/celo-org/celo-bls-go-android	v0.6.2
+	github.com/celo-org/celo-bls-go-ios	v0.6.2
+	github.com/celo-org/celo-bls-go-windows	v0.6.2
+	github.com/celo-org/celo-bls-go-other	v0.6.2
 )

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module github.com/celo-org/celo-bls-go
 go 1.12
 
 require (
-	github.com/celo-org/celo-bls-go-linux	v0.6.2
-	github.com/celo-org/celo-bls-go-macos	v0.6.2
-	github.com/celo-org/celo-bls-go-android	v0.6.2
-	github.com/celo-org/celo-bls-go-ios	v0.6.2
-	github.com/celo-org/celo-bls-go-windows	v0.6.2
-	github.com/celo-org/celo-bls-go-other	v0.6.2
+	github.com/celo-org/celo-bls-go-linux	v0.6.3
+	github.com/celo-org/celo-bls-go-macos	v0.6.3
+	github.com/celo-org/celo-bls-go-android	v0.6.3
+	github.com/celo-org/celo-bls-go-ios	v0.6.3
+	github.com/celo-org/celo-bls-go-windows	v0.6.3
+	github.com/celo-org/celo-bls-go-other	v0.6.3
 )

--- a/platforms/bls_router.go.template
+++ b/platforms/bls_router.go.template
@@ -92,7 +92,7 @@ func BatchVerifyStrict(batches []*Batch, shouldUseCompositeHasher, shouldUseCIP2
 }
 
 func DeserializeSignature(signatureBytes []byte) (*Signature, error) {
-	return DeserializeSignature(signatureBytes)
+	return blsRoute.DeserializeSignature(signatureBytes)
 }
 
 func AggregatePublicKeys(publicKeys []*PublicKey) (*PublicKey, error) {


### PR DESCRIPTION
Finishes fixing the infinite recursion bug noted in https://github.com/celo-org/celo-bls-go/pull/35.