### PR TITLE
Fix linux builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
   build-and-bundle-libs-all-targets:
     working_directory: ~/app
     macos:
-      xcode: 11.4.0
+      xcode: 13.4.1
     resource_class: large
     steps:
       - attach_workspace:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 celo-bls-go
 -----------
 
-Go module for [celo-bls-snark-rs](https://github.com/celo-org/celo-bls-snark-rs/).
+ Go module for [celo-bls-snark-rs](https://github.com/celo-org/celo-bls-snark-rs/).
 
 ## Release process
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 celo-bls-go
 -----------
 
- Go module for [celo-bls-snark-rs](https://github.com/celo-org/celo-bls-snark-rs/).
+Go module for [celo-bls-snark-rs](https://github.com/celo-org/celo-bls-snark-rs/).
 
 ## Release process
 

--- a/bls/bls_linux.go
+++ b/bls/bls_linux.go
@@ -1,4 +1,4 @@
-// +build linux,arm64 !android,linux,amd64,!musl linux,arm,!arm7 arm7 !android,linux,386,!musl !android,musl
+// +build !android,linux,arm64 !android,linux,amd64,!musl !android,linux,arm,!arm7 !android,arm7 !android,linux,386,!musl !android,musl !android,linux,mips !android,linux,mips64 !android,linux,mips64le !android,linux,mipsle
 
 package bls
 

--- a/bls/bls_linux.go
+++ b/bls/bls_linux.go
@@ -1,4 +1,4 @@
-// +build !android,linux,arm64 !android,linux,amd64,!musl !android,linux,arm,!arm7 !android,arm7 !android,linux,386,!musl !android,musl !android,linux,mips !android,linux,mips64 !android,linux,mips64le !android,linux,mipsle
+// +build linux,arm64 !android,linux,amd64,!musl linux,arm,!arm7 arm7 !android,linux,386,!musl !android,musl
 
 package bls
 


### PR DESCRIPTION
Fixes how the linux files are built by adding `!android` tags. Tested by running `make android` in `celo-blockchain` using this branch as a dependency. 